### PR TITLE
Parameterise Banner and DebianBanner as defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,6 +69,12 @@ ssh_print_motd: false      # sshd
 # false to disable display of last login information
 ssh_print_last_log: false    # sshd
 
+# false to disable serving /etc/ssh/banner.txt before authentication is allowed
+ssh_banner: false # sshd
+
+# false to disable distribution version leakage during initial protocol handshake
+ssh_print_debian_banner: false # sshd (Debian OS family only)
+
 # true to enable sftp configuration
 sftp_enabled: false
 

--- a/templates/openssh.conf.j2
+++ b/templates/openssh.conf.j2
@@ -3,8 +3,6 @@
 # This is the ssh client system-wide configuration file.
 # See ssh_config(5) for more information on any settings used. Comments will be added only to clarify why a configuration was chosen.
 #
-# Created for OpenSSH v5.9
-
 # Basic configuration
 # ===================
 

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -2,8 +2,6 @@
 
 # This is the ssh client system-wide configuration file.
 # See sshd_config(5) for more information on any settings used. Comments will be added only to clarify why a configuration was chosen.
-#
-# Created for OpenSSH v5.9
 
 # Basic configuration
 # ===================

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -198,10 +198,11 @@ PrintMotd {{ 'yes' if ssh_print_motd else 'no' }}
 
 PrintLastLog {{ 'yes' if ssh_print_last_log else 'no' }}
 
-#Banner /etc/ssh/banner.txt
-#UseDNS yes
-#PidFile /var/run/sshd.pid
-#MaxStartups 10
+Banner {{ '/etc/ssh/banner.txt' if ssh_banner else 'none' }}
+
+{% if ansible_os_family == 'Debian' %}
+DebianBanner {{ 'yes' if ssh_print_debian_banner else 'no' }}
+{% endif %}
 
 {% if sftp_enabled %}
 # Configuration, in case SFTP is used


### PR DESCRIPTION
This commit parameterises `Banner` and `DebianBanner` in the sshd config
with the defaults `ssh_banner` and `ssh_os_banner` respectively, though the
latter is only supported on Debian family distributions.

Debian based distributions will have `DebianBanner no` set by default
from now on.