### PR TITLE
Cannot restart sshd-service due to lack of privileges

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,4 @@
 - name: restart sshd
   service: name={{ sshd_service_name }} state=restarted
+  become: yes
+


### PR DESCRIPTION
Environment:
Raspbian Jessie on Raspberry PI 3+

When invoking this role with:

- hosts: toveri_JOE_ENO
  roles:
    #Configured in group_vars/all/ssh.yml
  - role: dev-sec.ssh-hardening
    become: yes
    tags: ['ssh']

Got this error when running handler "restart sshd":

    Unable to restart service ssh: Failed to restart ssh.service: Access denied

This patch fixes this.