### PR TITLE
Fix ssh config to handle custom options per Host

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_host_key_files` | ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_dsa_key', '/etc/ssh/ssh_host_ecdsa_key'] |Host keys to look for when starting sshd.|
 |`ssh_client_alive_interval` | 600 | specifies an interval for sending keepalive messages |
 |`ssh_client_alive_count` | 3 | defines how often keep-alive messages are sent |
-|`ssh_remote_hosts` | [] | one or more hosts, to which ssh-client can connect to. Default is empty, but should be configured for security reasons!|
+|`ssh_remote_hosts` | [] | one or more hosts and their custom options for the ssh-client. Default is empty. See examples in `defaults/main.yml`.|
 |`ssh_allow_root_with_key` | false | false to disable root login altogether. Set to true to allow root to login via key-based mechanism.|
 |`ssh_allow_tcp_forwarding` | false | false to disable TCP Forwarding. Set to true to allow TCP Forwarding.|
 |`ssh_allow_agent_forwarding` | false | false to disable Agent Forwarding. Set to true to allow Agent Forwarding.|

--- a/default.yml
+++ b/default.yml
@@ -1,5 +1,5 @@
 ---
-- name: wrapper playbook for kitchen testing "ansible-ssh-hardening" with default settings
+- name: wrapper playbook for kitchen testing "ansible-ssh-hardening" with custom settings
   hosts: localhost
   pre_tasks:
     - package: name="{{item}}" state=installed
@@ -13,5 +13,22 @@
         - "openssh-server"
       ignore_errors: true
     - file: path="/var/run/sshd" state=directory
+  roles:
+    - ansible-ssh-hardening
+  vars:
+    network_ipv6_enable: true
+    ssh_allow_root_with_key: true
+    ssh_client_password_login: true
+    ssh_client_cbc_required: true
+    ssh_server_weak_hmac: true
+    ssh_client_weak_kex: true
+    ssh_remote_hosts:
+      - names: ['example.com', 'example2.com']
+        options: ['Port 2222', 'ForwardAgent yes']
+      - names: ['example3.com']
+        options: ['StrictHostKeyChecking no']
+
+- name: wrapper playbook for kitchen testing "ansible-ssh-hardening" with default settings
+  hosts: localhost
   roles:
     - ansible-ssh-hardening

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,8 +37,16 @@ ssh_max_auth_retries: 2
 
 ssh_client_alive_interval: 600          # sshd
 ssh_client_alive_count: 3               # sshd
-# one or more hosts, to which ssh-client can connect to. Default is empty, but should be configured for security reasons!
-ssh_remote_hosts: []           # ssh
+
+# Hosts with custom options.            # ssh
+# Example:
+# ssh_remote_hosts:
+#   - names: ['example.com', 'example2.com']
+#     options: ['Port 2222', 'ForwardAgent yes']
+#   - names: ['example3.com']
+#     options: ['StrictHostKeyChecking no']
+ssh_remote_hosts: []
+
 # false to disable root login altogether. Set to true to allow root to login via key-based mechanism.
 ssh_allow_root_with_key: false          # sshd
 

--- a/templates/openssh.conf.j2
+++ b/templates/openssh.conf.j2
@@ -8,10 +8,18 @@
 
 # Address family should always be limited to the active network configuration.
 AddressFamily {{ 'any' if network_ipv6_enable else 'inet' }}
-# Restrict the following configuration to be limited to this Host.
+
 {% for host in ssh_remote_hosts -%}
-Host {{host}}
-{% endfor %}
+{% if loop.first %}
+# Host-specific configuration
+{% endif %}
+Host {{ host.names | join(' ') }}
+  {{ host.options | join("\n") | indent(2) }}
+
+{% endfor -%}
+
+# Global defaults for all Hosts
+Host *
 
 # The port at the destination should be defined
 {% for port in ssh_client_ports -%}


### PR DESCRIPTION
### Example problem
Currently, a config such as `ssh_remote_hosts: ['host1', 'host2']` would yield this in `ssh_config`:
```
# ssh_config

Host host1
Host host2
...
PasswordAuthentication no
...
```

Let's check the resulting `PasswordAuthentication` per host.
```bash
# shell

# this is expected
$ ssh -G host2 | grep passwordauth
passwordauthentication no

# this is probably unintended
$ ssh -G host1 | grep passwordauth
passwordauthentication yes

# same unintended `yes` for any host missing from `ssh_remote_hosts`
$ ssh -G host3 | grep passwordauth
passwordauthentication yes
```
`host2` is the only host to benefit from the secure ssh options set in this role. All other hosts would use the insecure defaults (e.g., including Ciphers, MACs, Kex, etc.).

### Proposed fix
Given that the purpose of this role is to create more secure ssh defaults for all hosts, I figure `ssh_remote_hosts` was intended as a place for users specify a few custom options that differ from the new secure defaults.

This PR changes the handling of `ssh_remote_hosts` such that a variable definition such as this...
```yaml
# defaults/main.yml

ssh_remote_hosts:
  - names: ['example.com', 'example2.com']
    options: ['Port 2222', 'ForwardAgent yes']
  - names: ['example3.com']
    options: ['StrictHostKeyChecking no']
```
... would produce this in the `ssh_config` ...
```
# ssh_config

# Host-specific configuration
Host example.com example2.com
  Port 2222
  ForwardAgent yes

Host example3.com
  StrictHostKeyChecking no

# Global defaults for all Hosts
Host *
...
```

That way all hosts get all the secure ssh defaults of this role, and users may specify custom overrides in `ssh_remote_hosts`.

### Notes
I believe this change does not affect tests in [dev-sec/ssh-baseline](https://github.com/dev-sec/ssh-baseline)'s current [`controls/ssh_spec.rb`](https://github.com/dev-sec/ssh-baseline/blob/75754b9b3fe45c601f0fa0036b01c61c8b8e26d9/controls/ssh_spec.rb).

However, changing the structure of the `ssh_remote_hosts` variable would be a **breaking change** for users with any definition other than `ssh_remote_hosts: []`. They would see templating errors unless they understand they must restructure their `ssh_remote_hosts` variable.

Maybe that error would be important as a way to call users' attention to the fact that their current `ssh_remote_hosts` may not be functioning as they expect. Or perhaps you would prefer to give a new name to this restructured variable, e.g., `ssh_options_per_host`. 

I believe the problem addressed in this PR is also present in [dev-sec/chef-ssh-hardening](https://github.com/dev-sec/chef-ssh-hardening) and [dev-sec/puppet-ssh-hardening](https://github.com/dev-sec/puppet-ssh-hardening).
