### PR TITLE
List only one Port in ssh config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_server_weak_hmac` | false |true if weaker HMAC mechanisms are required. This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure HMACs enabled.|
 |`ssh_client_weak_kex` | false |true if weaker Key-Exchange (KEX) mechanisms are required. This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure KEXs enabled.|
 |`ssh_server_weak_kex` | false |true if weaker Key-Exchange (KEX) mechanisms are required. This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure KEXs enabled.|
-|`ssh_server_ports` | ['22'] |ports to which ssh-server should listen to|
-|`ssh_client_ports` | ['22'] |ports to which ssh-client should connect to|
+|`ssh_server_ports` | ['22'] |ports on which ssh-server should listen|
+|`ssh_client_port` | '22' |port to which ssh-client should connect|
 |`ssh_listen_to` | ['0.0.0.0'] |one or more ip addresses, to which ssh-server should listen to. Default is all adresseses, but should be configured to specific addresses for security reasons!|
 |`ssh_host_key_files` | ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_dsa_key', '/etc/ssh/ssh_host_ecdsa_key'] |Host keys to look for when starting sshd.|
 |`ssh_client_alive_interval` | 600 | specifies an interval for sending keepalive messages |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,11 +20,11 @@ ssh_server_weak_kex: false              # sshd
 # If true, password login is allowed. For sshd, it is always set to no password login.
 ssh_client_password_login: false          # ssh
 
-# ports to which ssh-server should listen to
+# ports on which ssh-server should listen
 ssh_server_ports: ['22']      # sshd
 
-# ports to which ssh-client should connect to
-ssh_client_ports: ['22']      # ssh
+# port to which ssh-client should connect
+ssh_client_port: '22'         # ssh
 
 # one or more ip addresses, to which ssh-server should listen to. Default is empty, but should be configured for security reasons!
 ssh_listen_to: ['0.0.0.0']    # sshd

--- a/templates/openssh.conf.j2
+++ b/templates/openssh.conf.j2
@@ -14,9 +14,7 @@ Host {{host}}
 {% endfor %}
 
 # The port at the destination should be defined
-{% for port in ssh_client_ports -%}
-Port {{port}}
-{% endfor %}
+Port {{ ssh_client_port }}
 
 # Identity file configuration. You may restrict available identity files. Otherwise ssh will search for a pattern and use any that matches.
 #IdentityFile ~/.ssh/identity


### PR DESCRIPTION
### Minor potential confusion
Although `sshd_config` (server) will accommodate multiple `Port` values, `ssh_config` (client) will use only the first `Port` value listed.

The `ssh_client_ports` variable is currently structured as a list. An unlikely user who defines `ssh_client_ports: ['2222', '22']` may be surprised that no connection to `Port 22` will be attempted.

### Proposed fix
This is a trivial PR to avoid that potential confusion, changing the `ssh_client_ports` list variable into a simple non-list variable named `ssh_client_port`.

### Notes
I believe this change does not affect tests in [dev-sec/ssh-baseline](https://github.com/dev-sec/ssh-baseline)'s current [`controls/ssh_spec.rb`](https://github.com/dev-sec/ssh-baseline/blob/75754b9b3fe45c601f0fa0036b01c61c8b8e26d9/controls/ssh_spec.rb).

However, the change in variable name is a **breaking change** for users who have previously assigned a value to `ssh_client_ports` in their `group_vars` or play vars, etc. They would have to change the variable name. I suppose an attempt to avoid the problem would be to alter this PR like the example below, trying to capture the first list item in `ssh_client_ports` if the variable still exists (e.g., in `group_vars` etc.):

```diff
# templates/openssh.conf.j2

-Port {{ ssh_client_port }}
+Port {{ ssh_client_ports | default([ssh_client_port]) | first }}
```
**Edit:** ⬆️  Replaced original idea of `Port {{ ssh_client_ports[0] | default(ssh_client_port) }}` (fails)

I believe the issue addressed in this PR is also present in [dev-sec/chef-ssh-hardening](https://github.com/dev-sec/chef-ssh-hardening) and [dev-sec/puppet-ssh-hardening](https://github.com/dev-sec/puppet-ssh-hardening).