### PR TITLE
Defaults: Remove DSA from SSH host keys to match ssh-baseline profile

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ ssh_client_ports: ['22']      # ssh
 ssh_listen_to: ['0.0.0.0']    # sshd
 
 # Host keys to look for when starting sshd.
-ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_dsa_key', '/etc/ssh/ssh_host_ecdsa_key']        # sshd
+ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key']        # sshd
 
 # Specifies  the  maximum  number  of authentication attempts permitted per connection.  Once the number of failures reaches half this value, additional failures are logged.
 ssh_max_auth_retries: 2


### PR DESCRIPTION
This is a change in the default values, for consistency between dev-sec's repos.

Currently Ansible SSH hardening role configures DSA host key which does not pass InSpec's sshd-14.

Both: the [ssh-baseline profile](https://github.com/dev-sec/ssh-baseline/blob/master/controls/sshd_spec.rb#L163) and the [Chef recipe](https://github.com/dev-sec/chef-ssh-hardening/blob/master/attributes/default.rb#L76) specify only RSA and ECDSA, so I assume the intention was to exclude the DSA key and convergence should be achieved by removing it from Ansible's role.