### PR TITLE
Add Ed25519 SSH host key to match commit 28b4df3 in ssh-baseline

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ ssh_client_ports: ['22']      # ssh
 ssh_listen_to: ['0.0.0.0']    # sshd
 
 # Host keys to look for when starting sshd.
-ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key']        # sshd
+ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key']  # sshd
 
 # Specifies  the  maximum  number  of authentication attempts permitted per connection.  Once the number of failures reaches half this value, additional failures are logged.
 ssh_max_auth_retries: 2


### PR DESCRIPTION
[Commit 28b4df3](https://github.com/dev-sec/ssh-baseline/commit/28b4df3cc6a84ee2f5b6ae8d8d5fea942d08120f) introduced `ed25519` as required host key.