### PR TITLE
Accommodate missing plugins in kitchen_vagrant_block.rb

### DIFF
--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -23,10 +23,6 @@ provisioner:
 transport:
   max_ssh_sessions: 5
 
-transport:
-  max_ssh_sessions: 5
-
-
 platforms:
 - name: ubuntu-12.04
   driver_config:

--- a/kitchen_vagrant_block.rb
+++ b/kitchen_vagrant_block.rb
@@ -1,15 +1,19 @@
 # This is a Vagrant block to allow proxy settings to be carried into Kitchen
 # You need this for all of yum/apt etc. to work!
-unless ENV['http_proxy'].empty? || Vagrant.has_plugin?("vagrant-proxyconf")
+unless ENV['http_proxy'].nil? || Vagrant.has_plugin?("vagrant-proxyconf")
   raise "Missing required plugin 'vagrant-proxyconf' to support HTTP(S) proxies, run `vagrant plugin install vagrant-proxyconf`"
 end
 
 Vagrant.configure(2) do |config|
-  config.proxy.http     = "#{ENV['http_proxy']}"
-  config.proxy.https    = "#{ENV['https_proxy']}"
-  config.proxy.no_proxy = "localhost,127.0.0.1"
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    config.proxy.http     = "#{ENV['http_proxy']}"
+    config.proxy.https    = "#{ENV['https_proxy']}"
+    config.proxy.no_proxy = "localhost,127.0.0.1"
+  end
 
   # You may have vagrant-vbguest plugin installed to keep your images up to date
   # - but will probably have VBoxAddition build issues with the foreign boxes listed in .kitchen.vagrant.yml
-  config.vbguest.auto_update = false
+  if Vagrant.has_plugin?("vagrant-vbguest")
+    config.vbguest.auto_update = false
+  end
 end


### PR DESCRIPTION
1. Makes plugin-specific Vagrant configs conditional, preventing failure:
```
       Vagrant:
       * Unknown configuration section 'proxy'.
       * Unknown configuration section 'vbguest'.
```

2. Accommodates missing `http_proxy` environment variable, which will be nil, preventing failure:
```
NoMethodError: undefined method `empty?' for nil:NilClass
```

3. Also removes duplicate `transport` introduced in d12627a