### PR TITLE
fix validation error

### DIFF
--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -190,6 +190,8 @@ GatewayPorts no
 X11Forwarding no
 X11UseLocalhost yes
 
+# Look up the remote host name, defaults to false from 6.8, see: http://www.openssh.com/txt/release-6.8
+UseDNS {{ 'yes' if ssh_use_dns else 'no' }}
 
 # Misc. configuration
 # ===================
@@ -222,6 +224,3 @@ PasswordAuthentication no
 PermitRootLogin no
 X11Forwarding no
 {% endif %}
-
-#  look up the remote host name, defaults to false from 6.8, see: http://www.openssh.com/txt/release-6.8
-UseDNS {{ 'yes' if ssh_use_dns else 'no' }}


### PR DESCRIPTION
In 4.1.0 the `UseDNS` fragment was added to the sshd template. This causes a validation error when `sftp_enabled ` is `true`, because it's below `Match Group sftponly` and sshd interprets this line to be inside the Match block:

```
...
TASK [dev-sec.ssh-hardening : create sshd_config and set permissions to root/600] ***
fatal: [default]: FAILED! => {"changed": true, "exit_status": 255, "failed": true, "msg": "failed to validate", "stderr": "/home/vagrant/.ansible/tmp/ansible-tmp-1494819613.2-15252609610528/source line 164: Directive 'UseDNS' is not allowed within a Match block\r\n", 
...
```

This PR moves the `UseDNS` fragment up into the network section to resolve this.