### PR TITLE
added check_mode: no to "get openssh-version" task, so it won't fail …

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
   shell: ssh -V 2>&1 | sed -r 's/.*_([0-9]*\.[0-9]).*/\1/g'
   changed_when: false
   register: sshd_version
+  check_mode: no
 
 - name: set hostkeys according to openssh-version
   set_fact:


### PR DESCRIPTION
…in check-mode

@rndmh3ro, this will fix issue #111 which was discovered by @aerowork