### PR TITLE
use package instead of yum so the operation works on Fedora

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,7 @@
 
 - block: # only runs when selinux is running
   - name: install selinux dependencies when selinux is installed on RHEL or Oracle Linux
-    yum: name="{{item}}" state=installed
+    package: name="{{item}}" state=installed
     with_items:
       - policycoreutils-python
       - checkpolicy


### PR DESCRIPTION
"package" is a distro-agnostic Ansible module added to the main modules in Ansible 2.0. Fedora uses "dnf" package manager and no longer includes Yum in current versions; because of this the "yum" module causes the playbook to fail on Fedora OS. Using "package" allows the playbook to run on fedora/centos/rhel. 