### PR TITLE
Add comment filter to {{ansible_managed}} string

### DIFF
--- a/templates/openssh.conf.j2
+++ b/templates/openssh.conf.j2
@@ -1,4 +1,4 @@
-# {{ansible_managed}}
+# {{ansible_managed|comment}}
 
 # This is the ssh client system-wide configuration file.
 # See ssh_config(5) for more information on any settings used. Comments will be added only to clarify why a configuration was chosen.

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -1,4 +1,4 @@
-# {{ansible_managed}}
+# {{ansible_managed|comment}}
 
 # This is the ssh client system-wide configuration file.
 # See sshd_config(5) for more information on any settings used. Comments will be added only to clarify why a configuration was chosen.

--- a/templates/revoked_keys.j2
+++ b/templates/revoked_keys.j2
@@ -1,4 +1,4 @@
-# {{ansible_managed}}
+# {{ansible_managed|comment}}
 {% for key in ssh_server_revoked_keys %}
 {{key}}
 {% endfor %}


### PR DESCRIPTION
Multiline `{{ansible_managed}}` strings do not get properly commented without the `comment` filter.
See http://docs.ansible.com/ansible/playbooks_filters.html#comment-filter