### PR TITLE
Don't overwrite ssh_host_key_files if set manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_server_ports` | ['22'] |ports on which ssh-server should listen|
 |`ssh_client_port` | '22' |port to which ssh-client should connect|
 |`ssh_listen_to` | ['0.0.0.0'] |one or more ip addresses, to which ssh-server should listen to. Default is all adresseses, but should be configured to specific addresses for security reasons!|
-|`ssh_host_key_files` | ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_dsa_key', '/etc/ssh/ssh_host_ecdsa_key'] |Host keys to look for when starting sshd.|
+|`ssh_host_key_files` | [] |Host keys for sshd. If empty ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key'] will be used, as far as supported by the installed sshd version|
 |`ssh_client_alive_interval` | 600 | specifies an interval for sending keepalive messages |
 |`ssh_client_alive_count` | 3 | defines how often keep-alive messages are sent |
 |`ssh_permit_tunnel` | false | true if SSH Port Tunneling is required |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ ssh_client_port: '22'         # ssh
 ssh_listen_to: ['0.0.0.0']    # sshd
 
 # Host keys to look for when starting sshd.
-ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key']  # sshd
+ssh_host_key_files: []  # sshd
 
 # Specifies  the  maximum  number  of authentication attempts permitted per connection.  Once the number of failures reaches half this value, additional failures are logged.
 ssh_max_auth_retries: 2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,18 +15,18 @@
 
 - name: set hostkeys according to openssh-version
   set_fact:
-    ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key']
-  when: sshd_version.stdout >= '5.3'
+    ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key']
+  when: sshd_version.stdout >= '6.3' and not ssh_host_key_files
 
 - name: set hostkeys according to openssh-version
   set_fact:
     ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key']
-  when: sshd_version.stdout >= '6.0'
+  when: sshd_version.stdout >= '6.0' and not ssh_host_key_files
 
 - name: set hostkeys according to openssh-version
   set_fact:
-    ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key']
-  when: sshd_version.stdout >= '6.3'
+    ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key']
+  when: sshd_version.stdout >= '5.3' and not ssh_host_key_files
 
 - name: create revoked_keys and set permissions to root/600
   template: src='revoked_keys.j2' dest='/etc/ssh/revoked_keys' mode=0600 owner="{{ ssh_owner }}" group="{{ ssh_group }}"


### PR DESCRIPTION
before the manually set `ssh_host_key_files` would be overwritten if the openssh-version was greater than 5.3