### PR TITLE
Remove duplicate ssh_use_dns

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -175,8 +175,5 @@ sshd_moduli_minimum: 2048
 # disable ChallengeResponseAuthentication
 ssh_challengeresponseauthentication: false
 
-#  look up the remote host name, defaults to false from 6.8, see: http://www.openssh.com/txt/release-6.8
-ssh_use_dns: false
-
 # a list of public keys that are never accepted by the ssh server
 ssh_server_revoked_keys: []


### PR DESCRIPTION
ssh_use_dns was set twice in defaults/main.yml. This patch removes the last occurrence.

Fixes #129