### PR TITLE
Added support for AuthorizedKeysFile config setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_allow_users` | '' | if specified, login is allowed only for user names that match one of the patterns.|
 |`ssh_deny_groups` | '' | if specified, login is disallowed for users whose primary group or supplementary group list matches one of the patterns.|
 |`ssh_allow_groups` | '' | if specified, login is allowed only for users whose primary group or supplementary group list matches one of the patterns.|
+|`ssh_authorized_keys_file` | '' | change default file that contains the public keys that can be used for user authentication.|
 |`ssh_print_motd` | false | false to disable printing of the MOTD|
 |`ssh_print_last_log` | false | false to disable display of last login information|
 |`sftp_enabled` | false | true to enable sftp configuration|

--- a/default.yml
+++ b/default.yml
@@ -36,6 +36,7 @@
     ssh_allow_groups: 'root kitchen vagrant'
     ssh_deny_users: 'foo bar'
     ssh_deny_groups: 'foo bar'
+    ssh_authorized_keys_file: '/etc/ssh/authorized_keys/%u'
     ssh_max_auth_retries: 10
     ssh_permit_tunnel: true
     ssh_print_motd: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,6 +84,9 @@ ssh_deny_groups: ''      # sshd
 # if specified, login is allowed only for users whose primary group or supplementary group list matches one of the patterns.
 ssh_allow_groups: ''      # sshd
 
+# change default file that contains the public keys that can be used for user authentication.
+ssh_authorized_keys_file: ''      # sshd
+
 # false to disable printing of the MOTD
 ssh_print_motd: false      # sshd
 

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -161,6 +161,10 @@ DenyGroups {{ssh_deny_groups}}
 AllowGroups {{ssh_allow_groups}}
 {% endif %}
 
+{% if ssh_authorized_keys_file %}
+AuthorizedKeysFile {{ ssh_authorized_keys_file }}
+{% endif %}
+
 # Network
 # -------
 


### PR DESCRIPTION
I created this small patch to add variable for AuthorizedKeysFile settings. I needed this for my setup, maybe it is useful to someone else as well.

From man sshd_config:
```
AuthorizedKeysFile
        Specifies the file that contains the public keys that can be used
        for user authentication.  The format is described in the AUTHO‐
        RIZED_KEYS FILE FORMAT section of sshd(8).  AuthorizedKeysFile
        may contain tokens of the form %T which are substituted during
        connection setup.  The following tokens are defined: %% is
        replaced by a literal '%', %h is replaced by the home directory
        of the user being authenticated, and %u is replaced by the user‐
        name of that user.  After expansion, AuthorizedKeysFile is taken
        to be an absolute path or one relative to the user's home direc‐
        tory.  Multiple files may be listed, separated by whitespace.
        Alternately this option may be set to “none” to skip checking for
        user keys in files.  The default is “.ssh/authorized_keys
        .ssh/authorized_keys2”.
```

sshd_config if ssh_authorized_keys_file is omitted
```
...
# Only enable GSSAPI authentication if it is configured.
GSSAPIAuthentication no
GSSAPICleanupCredentials yes

# In case you don't use PAM (`UsePAM no`), you can alternatively restrict users and groups here. For key-based authentication this is not necessary, since all keys must be explicitely enabled.





# Network
# -------

# Disable TCP keep alive since it is spoofable. Use ClientAlive messages instead, they use the encrypted channel
TCPKeepAlive no
...
```

sshd_config if ssh_authorized_keys_file is set

```
...
# Only enable GSSAPI authentication if it is configured.
GSSAPIAuthentication no
GSSAPICleanupCredentials yes

# In case you don't use PAM (`UsePAM no`), you can alternatively restrict users and groups here. For key-based authentication this is not necessary, since all keys must be explicitely enabled.




AuthorizedKeysFile /etc/ssh/authorized_keys/%u

# Network
# -------

# Disable TCP keep alive since it is spoofable. Use ClientAlive messages instead, they use the encrypted channel
TCPKeepAlive no
...
```
