### PR TITLE
force /bin/sh when getting openssh-version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,8 @@
 
 - name: get openssh-version
   shell: ssh -V 2>&1 | sed -r 's/.*_([0-9]*\.[0-9]).*/\1/g'
+  args:
+    executable: /bin/sh
   changed_when: false
   register: sshd_version
   check_mode: no


### PR DESCRIPTION
(since the update to ansible 2.4.0.0) the C shell is used
on FreeBSD to run shell  tasks.  This breakes the
redirect.

Forcing /bin/sh fixes this.

Closes #133