### PR TITLE
allow configuration of GatewayPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_remote_hosts` | [] | one or more hosts and their custom options for the ssh-client. Default is empty. See examples in `defaults/main.yml`.|
 |`ssh_allow_root_with_key` | false | false to disable root login altogether. Set to true to allow root to login via key-based mechanism.|
 |`ssh_allow_tcp_forwarding` | false | false to disable TCP Forwarding. Set to true to allow TCP Forwarding.|
+|`ssh_gateway_ports` | `false` | `false` to disable binding forwarded ports to non-loopback addresses. Set to `true` to force binding on wildcard address. Set to `clientspecified` to allow the client to specify which address to bind to.|
 |`ssh_allow_agent_forwarding` | false | false to disable Agent Forwarding. Set to true to allow Agent Forwarding.|
 |`ssh_use_pam` | false | false to disable pam authentication.|
 |`ssh_deny_users` | '' | if specified, login is disallowed for user names that match one of the patterns.|

--- a/default.yml
+++ b/default.yml
@@ -23,6 +23,7 @@
     network_ipv6_enable: true
     ssh_allow_root_with_key: true
     ssh_allow_tcp_forwarding: true
+    ssh_gateway_ports: true
     ssh_allow_agent_forwarding: true
     ssh_server_permit_environment_vars: ['PWD','HTTP_PROXY']
     ssh_client_alive_interval: 100

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,10 @@ ssh_allow_root_with_key: false          # sshd
 # false to disable TCP Forwarding. Set to true to allow TCP Forwarding.
 ssh_allow_tcp_forwarding: false         # sshd
 
+# false to disable binding forwarded ports to non-loopback addresses. Set to true to force binding on wildcard address.
+# Set to 'clientspecified' to allow the client to specify which address to bind to.
+ssh_gateway_ports: false                # sshd
+
 # false to disable Agent Forwarding. Set to true to allow Agent Forwarding.
 ssh_allow_agent_forwarding: false       # sshd
 

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -186,8 +186,16 @@ AllowTcpForwarding {{ 'yes' if (ssh_allow_tcp_forwarding|bool) else 'no' }}
 # no real advantage without denied shell access
 AllowAgentForwarding {{ 'yes' if (ssh_allow_agent_forwarding|bool) else 'no' }}
 
+{% if ssh_gateway_ports|bool %}
+# Port forwardings are forced to bind to the wildcard address
+GatewayPorts yes
+{% elif ssh_gateway_ports == 'clientspecified' %}
+# Clients allowed to specify which address to bind port forwardings to
+GatewayPorts clientspecified
+{% else %}
 # Do not allow remote port forwardings to bind to non-loopback addresses.
 GatewayPorts no
+{% endif %}
 
 # Disable X11 forwarding, since local X11 display could be accessed through forwarded connection.
 X11Forwarding no


### PR DESCRIPTION
This is a small PR to allow configuration of the sshd `GatewayPorts` directive. This is useful for hosts that act as a bastion host, where clients are proxying local server ports though it and want to expose on a non loopback address.