### PR TITLE
Issue #137: Fix sshd_config's "Match Group sftponly"

### DIFF
--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -238,13 +238,13 @@ Subsystem sftp internal-sftp -l INFO -f LOCAL6
 
 # These lines must appear at the *end* of sshd_config
 Match Group sftponly
-ForceCommand internal-sftp -l INFO -f LOCAL6
-ChrootDirectory {{ sftp_chroot_dir }}
-AllowTcpForwarding no
-AllowAgentForwarding no
-PasswordAuthentication no
-PermitRootLogin no
-X11Forwarding no
+    ForceCommand internal-sftp -l INFO -f LOCAL6
+    ChrootDirectory {{ sftp_chroot_dir }}
+    AllowTcpForwarding no
+    AllowAgentForwarding no
+    PasswordAuthentication no
+    PermitRootLogin no
+    X11Forwarding no
 {% endif %}
 
 {% if ssh_server_match_group %}


### PR DESCRIPTION
The "sftponly" Match Group in the sshd_config was not indented properly, so the settings that should only apply to sftp connections were overriding the global settings earlier in the file.