### PR TITLE
Remove deprecated UseLogin option

### DIFF
--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -110,7 +110,6 @@ LogLevel VERBOSE
 # --------------
 
 # Secure Login directives.
-UseLogin no
 UsePrivilegeSeparation {% if (ansible_distribution == 'Debian' and ansible_distribution_major_version <= '6') or (ansible_os_family in ['Oracle Linux', 'RedHat'] and ansible_distribution_major_version <= '6') -%}{{ssh_ps53}}{% else %}{{ssh_ps59}}{% endif %}
 
 LoginGraceTime 30s


### PR DESCRIPTION
Since OpenSSH 7.4/7.4p1 (2016-12-19)[0] (The default in Debian Stretch,
CentOS 7 and others) the "UseLogin" option has been deprecated.

Setting this option originally prevented usage of a "traditional"
/usr/sbin/login-based login – but has been set to "no" by default since
quite a while, so even if this role would be applied on a host with an
older OpenSSH version, the default value should still be save.

Fixes #140

0. https://www.openssh.com/txt/release-7.4