### PR TITLE
conform to current dev-sec/ssh-baseline

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,7 +45,7 @@ ssh_host_key_files: []  # sshd
 # Specifies  the  maximum  number  of authentication attempts permitted per connection.  Once the number of failures reaches half this value, additional failures are logged.
 ssh_max_auth_retries: 2
 
-ssh_client_alive_interval: 600          # sshd
+ssh_client_alive_interval: 300          # sshd
 ssh_client_alive_count: 3               # sshd
 
 # Allow SSH Tunnels


### PR DESCRIPTION
Cf. https://github.com/dev-sec/ssh-baseline/pull/98
Cf. https://github.com/dev-sec/ssh-baseline/blob/master/controls/sshd_spec.rb#L172
Given the discussion in https://github.com/dev-sec/ansible-ssh-hardening/pull/141, not (re)adding `UseLogin no`; however, for local inspec tests I suggest adding something similar to https://github.com/dev-sec/chef-os-hardening/blob/master/test/integration/default/controls/tests.rb