### PR TITLE
Adds sshd config for keyboard-interactive pam device

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_client_password_login` | false | `true` to allow password-based authentication with the ssh client |
 |`ssh_server_password_login` | false | `true` to allow password-based authentication with the ssh server |
 |`ssh_google_auth` | false | `true` to enable google authenticator based TOTP 2FA |
+|`ssh_pam_device` | false | `true` to enable  public key auth with pam device 2FA |
 |`ssh_banner` | `false` | `true` to print a banner on login |
 |`ssh_client_hardening` | `true` | `false` to stop harden the client |
 |`ssh_client_port` | `'22'` | Specifies the port number to connect on the remote host. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,6 +79,9 @@ ssh_use_pam: false      # sshd
 # false to disable google 2fa authentication
 ssh_google_auth: false # sshd
 
+# false to disable pam device 2FA input
+ssh_pam_device: false # sshd
+
 # if specified, login is disallowed for user names that match one of the patterns.
 ssh_deny_users: ''      # sshd
 

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -97,6 +97,11 @@ UsePAM {{ 'yes' if (ssh_use_pam|bool) else 'no' }}
 AuthenticationMethods publickey,keyboard-interactive
 {% endif %}
 
+# Force public key auth then ask for pam device input
+{% if ssh_pam_device %}
+AuthenticationMethods publickey,keyboard-interactive:pam
+{% endif %}
+
 # Disable password-based authentication, it can allow for potentially easier brute-force attacks.
 PasswordAuthentication {{ 'yes' if (ssh_server_password_login|bool) else 'no' }}
 PermitEmptyPasswords no


### PR DESCRIPTION
- Adds configuration option for public key authentication with 2FA input
from a PAM device such as a Yubikey. This will allow keyboard
interaction from the _device only_. See the documentation on
AuthenticationMethods
[here](https://www.freebsd.org/cgi/man.cgi?sshd_config(5)).