### PR TITLE
Allow weak MACs for ssh client

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -130,6 +130,7 @@ ssh_ps53: 'yes'
 ssh_ps59: 'sandbox'
 
 ssh_macs: []
+sshd_macs: []
 ssh_ciphers: []
 ssh_kex: []
 
@@ -151,6 +152,8 @@ ssh_macs_66_default:
   - hmac-sha2-512
   - hmac-sha2-256
 
+ssh_macs_66_weak: "{{ ssh_macs_66_default + ['hmac-sha1'] }}"
+
 ssh_macs_76_default:
   - hmac-sha2-512-etm@openssh.com
   - hmac-sha2-256-etm@openssh.com
@@ -158,7 +161,7 @@ ssh_macs_76_default:
   - hmac-sha2-512
   - hmac-sha2-256
 
-ssh_macs_66_weak: "{{ ssh_macs_66_default + ['hmac-sha1'] }}"
+ssh_macs_76_weak: "{{ ssh_macs_76_default + ['hmac-sha1'] }}"
 
 ssh_ciphers_53_default:
   - aes256-ctr

--- a/tasks/crypto.yml
+++ b/tasks/crypto.yml
@@ -15,17 +15,22 @@
     ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key']
   when: sshd_version.stdout >= '5.3' and not ssh_host_key_files
 
-###
+### Set MACs for ssh
 
 - name: set weak macs according to openssh-version if openssh >= 7.6
   set_fact:
-    ssh_macs: "{{ssh_macs_76_default}}"
+    ssh_macs: "{{ssh_macs_76_weak}}"
+  when: sshd_version.stdout >= '7.6' and ssh_client_weak_hmac and not ssh_macs
+
+- name: set macs according to openssh-version if openssh >= 7.6
+  set_fact:
+    ssh_macs: "{{ssh_macs_76_weak}}"
   when: sshd_version.stdout >= '7.6' and not ssh_macs
 
 - name: set weak macs according to openssh-version if openssh >= 6.6
   set_fact:
     ssh_macs: "{{ssh_macs_66_weak}}"
-  when: sshd_version.stdout >= '6.6' and ssh_server_weak_hmac and not ssh_macs
+  when: sshd_version.stdout >= '6.6' and ssh_client_weak_hmac and not ssh_macs
 
 - name: set macs according to openssh-version if openssh >= 6.6
   set_fact:
@@ -35,7 +40,7 @@
 - name: set weak macs according to openssh-version
   set_fact:
     ssh_macs: "{{ssh_macs_59_weak}}"
-  when: sshd_version.stdout >= '5.9' and ssh_server_weak_hmac and not ssh_macs
+  when: sshd_version.stdout >= '5.9' and ssh_client_weak_hmac and not ssh_macs
 
 - name: set macs according to openssh-version
   set_fact:
@@ -51,6 +56,43 @@
   set_fact:
     ssh_macs: "{{ssh_macs_53_default}}"
   when: sshd_version.stdout >= '5.3' and not ssh_macs
+
+### Set MACs for sshd
+
+- name: set weak macs according to openssh-version if openssh >= 7.6
+  set_fact:
+    sshd_macs: "{{ssh_macs_76_default}}"
+  when: sshd_version.stdout >= '7.6' and not sshd_macs
+
+- name: set weak macs according to openssh-version if openssh >= 6.6
+  set_fact:
+    sshd_macs: "{{ssh_macs_66_weak}}"
+  when: sshd_version.stdout >= '6.6' and ssh_server_weak_hmac and not sshd_macs
+
+- name: set macs according to openssh-version if openssh >= 6.6
+  set_fact:
+    sshd_macs: "{{ssh_macs_66_default}}"
+  when: sshd_version.stdout >= '6.6' and not sshd_macs
+
+- name: set weak macs according to openssh-version
+  set_fact:
+    sshd_macs: "{{ssh_macs_59_weak}}"
+  when: sshd_version.stdout >= '5.9' and ssh_server_weak_hmac and not sshd_macs
+
+- name: set macs according to openssh-version
+  set_fact:
+    sshd_macs: "{{ssh_macs_59_default}}"
+  when: sshd_version.stdout >= '5.9' and not sshd_macs
+
+- name: set macs according to openssh-version
+  set_fact:
+    sshd_macs: "{{ssh_macs_53_default}}"
+  when: sshd_version.stdout >= '5.3' and not sshd_macs
+
+- name: set macs according to openssh-version
+  set_fact:
+    sshd_macs: "{{ssh_macs_53_default}}"
+  when: sshd_version.stdout >= '5.3' and not sshd_macs
 
 ###
 
@@ -95,4 +137,3 @@
   set_fact:
     ssh_kex: "{{ssh_kex_59_default}}"
   when: sshd_version.stdout >= '5.9' and not ssh_kex
-

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -57,8 +57,8 @@ LogLevel VERBOSE
 # eg Ruby's Net::SSH at around 2.2.* doesn't support sha2 for hmac, so this will have to be set true in this case.
 #
 
-{# This outputs "MACs <list-of-macs>" if ssh_macs is defined or "#MACs" if ssh_macs is undefined #}
-{{ "MACs "+ssh_macs| join(',') if ssh_macs else "MACs"|comment }}
+{# This outputs "MACs <list-of-macs>" if sshd_macs is defined or "#MACs" if sshd_macs is undefined #}
+{{ "MACs "+sshd_macs| join(',') if sshd_macs else "MACs"|comment }}
 
 # Alternative setting, if OpenSSH version is below v5.9
 #MACs hmac-ripemd160


### PR DESCRIPTION
Define SSH client and SSH server macs separately and enable proper functionality of `ssh_client_weak_hmac` variable. 