### PR TITLE
Added support for TrustedUserCAKeys and AuthorizedPrincipalsFile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_deny_groups` | '' | if specified, login is disallowed for users whose primary group or supplementary group list matches one of the patterns.|
 |`ssh_allow_groups` | '' | if specified, login is allowed only for users whose primary group or supplementary group list matches one of the patterns.|
 |`ssh_authorized_keys_file` | '' | change default file that contains the public keys that can be used for user authentication.|
+|`ssh_trusted_user_ca_keys_file` | '' | specifies the file containing trusted certificate authorities public keys used to sign user certificates. |
+|`ssh_trusted_user_ca_keys` | [] | set the trusted certificate authorities public keys used to sign user certificates. Only used if ssh_trusted_user_ca_keys_file is set. |
+|`ssh_authorized_principals_file` | '' | specifies the file containing principals that are allowed. Only used if ssh_trusted_user_ca_keys_file is set. |
+|`ssh_authorized_principals` | [] | list of hashes containing file paths and authorized principals, see default_custom.yml for all options. Only used if ssh_authorized_principals_file is set. |
 |`ssh_print_motd` | false | false to disable printing of the MOTD|
 |`ssh_print_last_log` | false | false to disable display of last login information|
 |`sftp_enabled` | false | true to enable sftp configuration|

--- a/default_custom.yml
+++ b/default_custom.yml
@@ -61,3 +61,9 @@
     ssh_use_dns: true
     ssh_use_pam: true
     ssh_max_startups: '10:30:60'
+    ssh_trusted_user_ca_keys_file: '/etc/ssh/ca.pub'
+    ssh_trusted_user_ca_keys:
+      - '# ssh-rsa ...'
+    ssh_authorized_principals_file: '/etc/ssh/auth_principals/%u'
+    ssh_authorized_principals :
+      - { path: '/etc/ssh/auth_principals/root', principals: [ 'root' ], owner: "{{ ssh_owner }}", group: "{{ ssh_group }}", directoryowner: "{{ ssh_owner }}", directorygroup: "{{ ssh_group}}" }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -98,12 +98,27 @@ ssh_authorized_keys_file: ''      # sshd
 ssh_trusted_user_ca_keys_file: ''      # sshd
 
 # set the trusted certificate authorities public keys used to sign user certificates.
+# Example:
+# ssh_trusted_user_ca_keys:
+#   - 'ssh-rsa ... comment1'
+#   - 'ssh-rsa ... comment2'
 ssh_trusted_user_ca_keys: []      # sshd
 
 # specifies the file containing principals that are allowed. Only used if ssh_trusted_user_ca_keys_file is set.
+# Example:
+# ssh_authorized_principals_file: '/etc/ssh/auth_principals/%u'
+#
+# %h is replaced by the home directory of the user being authenticated, and %u is
+# replaced by the username of that user. After expansion, the path is taken to be
+# an absolute path or one relative to the user's home directory.
+#
 ssh_authorized_principals_file: ''      # sshd
 
 # list of hashes containing file paths and authorized principals. Only used if ssh_authorized_principals_file is set.
+# Example:
+# ssh_authorized_principals:
+#   - { path: '/etc/ssh/auth_principals/root', principals: [ 'root' ], owner: "{{ ssh_owner }}", group: "{{ ssh_group }}", directoryowner: "{{ ssh_owner }}", directorygroup: "{{ ssh_group}}" }
+#   - { path: '/etc/ssh/auth_principals/myuser', principals: [ 'masteradmin', 'webserver' ] }
 ssh_authorized_principals: []      # sshd
 
 # false to disable printing of the MOTD

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,6 +94,18 @@ ssh_allow_groups: ''      # sshd
 # change default file that contains the public keys that can be used for user authentication.
 ssh_authorized_keys_file: ''      # sshd
 
+# specifies the file containing trusted certificate authorities public keys used to sign user certificates.
+ssh_trusted_user_ca_keys_file: ''      # sshd
+
+# set the trusted certificate authorities public keys used to sign user certificates.
+ssh_trusted_user_ca_keys: []      # sshd
+
+# specifies the file containing principals that are allowed. Only used if ssh_trusted_user_ca_keys_file is set.
+ssh_authorized_principals_file: ''      # sshd
+
+# list of hashes containing file paths and authorized principals. Only used if ssh_authorized_principals_file is set.
+ssh_authorized_principals: []      # sshd
+
 # false to disable printing of the MOTD
 ssh_print_motd: false      # sshd
 

--- a/tasks/ca_keys_and_principals.yml
+++ b/tasks/ca_keys_and_principals.yml
@@ -1,0 +1,12 @@
+---
+- name: Set ssh CA pub keys
+  template: src='trusted_user_ca_keys.j2' dest="{{ ssh_trusted_user_ca_keys_file }}" mode=0644 owner="{{ ssh_owner }}" group="{{ ssh_group }}"
+  notify: restart sshd
+
+- name: Create ssh authorized principals directories
+  file: path="{{ item.path | dirname }}" mode="{{ item.directorymode | default(0700) }}" owner="{{ item.directoryowner | default(ssh_owner) }}" group="{{ item.directorygroup | default(ssh_group) }}" state=directory
+  with_items: "{{ ssh_authorized_principals }}"
+
+- name: Set ssh authorized principals
+  template: src='authorized_principals.j2' dest="{{ item.path }}" mode="{{ item.filemode | default(0600) }}" owner="{{ item.owner| default(ssh_owner) }}" group="{{ item.group | default(ssh_group) }}"
+  with_items: "{{ ssh_authorized_principals }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,20 +43,8 @@
   notify: restart sshd
   when: sshd_register_moduli.stdout
 
-- name: Set ssh CA pub keys
-  template: src='trusted_user_ca_keys.j2' dest="{{ ssh_trusted_user_ca_keys_file }}" mode=0644 owner="{{ ssh_owner }}" group="{{ ssh_group }}"
-  notify: restart sshd
+- include_tasks: ca_keys_and_principals.yml
   when: ssh_trusted_user_ca_keys_file != ''
-
-- name: Create ssh authorized principals directories
-  file: path="{{ item.path | dirname }}" mode="{{ item.directorymode | default(0700) }}" owner="{{ item.directoryowner | default(ssh_owner) }}" group="{{ item.directorygroup | default(ssh_group) }}" state=directory
-  when: ssh_trusted_user_ca_keys_file != ''
-  with_items: "{{ ssh_authorized_principals }}"
-
-- name: Set ssh authorized principals
-  template: src='authorized_principals.j2' dest="{{ item.path }}" mode="{{ item.filemode | default(0600) }}" owner="{{ item.owner| default(ssh_owner) }}" group="{{ item.group | default(ssh_group) }}"
-  when: ssh_trusted_user_ca_keys_file != ''
-  with_items: "{{ ssh_authorized_principals }}"
 
 - name: test to see if selinux is installed and running
   command: getenforce

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,21 @@
   notify: restart sshd
   when: sshd_register_moduli.stdout
 
+- name: Set ssh CA pub keys
+  template: src='trusted_user_ca_keys.j2' dest="{{ ssh_trusted_user_ca_keys_file }}" mode=0644 owner="{{ ssh_owner }}" group="{{ ssh_group }}"
+  notify: restart sshd
+  when: ssh_trusted_user_ca_keys_file != ''
+
+- name: Create ssh authorized principals directories
+  file: path="{{ item.path | dirname }}" mode="{{ item.directorymode | default(0700) }}" owner="{{ item.directoryowner | default(ssh_owner) }}" group="{{ item.directorygroup | default(ssh_group) }}" state=directory
+  when: ssh_trusted_user_ca_keys_file != ''
+  with_items: "{{ ssh_authorized_principals }}"
+
+- name: Set ssh authorized principals
+  template: src='authorized_principals.j2' dest="{{ item.path }}" mode="{{ item.filemode | default(0600) }}" owner="{{ item.owner| default(ssh_owner) }}" group="{{ item.group | default(ssh_group) }}"
+  when: ssh_trusted_user_ca_keys_file != ''
+  with_items: "{{ ssh_authorized_principals }}"
+
 - name: test to see if selinux is installed and running
   command: getenforce
   register: sestatus

--- a/templates/authorized_principals.j2
+++ b/templates/authorized_principals.j2
@@ -1,0 +1,5 @@
+# {{ansible_managed|comment}}
+
+{% for principal in item.principals %}
+{{ principal }}
+{% endfor %}

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -133,6 +133,13 @@ AllowGroups {{ssh_allow_groups}}
 AuthorizedKeysFile {{ ssh_authorized_keys_file }}
 {% endif %}
 
+{% if ssh_trusted_user_ca_keys_file %}
+TrustedUserCAKeys {{ ssh_trusted_user_ca_keys_file }}
+{%    if ssh_authorized_principals_file  %}
+AuthorizedPrincipalsFile {{ ssh_authorized_principals_file }}
+{%     endif %}
+{% endif %}
+
 # Network
 # -------
 

--- a/templates/trusted_user_ca_keys.j2
+++ b/templates/trusted_user_ca_keys.j2
@@ -1,0 +1,5 @@
+# {{ansible_managed|comment}}
+
+{% for item in ssh_trusted_user_ca_keys %}
+{{ item }}
+{% endfor %}


### PR DESCRIPTION
This PR allow the configuration for `TrustedUserCAKeys` and `AuthorizedPrincipalsFile` globally. 

It will also write trusted certificate authorities public keys and principals if defined in the file defined by `ssh_trusted_user_ca_keys_file` and by `ssh_authorized_principals.path`.

The format for the principals hash is : 
- path: the path of the file that will contains principals
- principals: a list of principals
- owner: the file owner (defaults to ssh_owner)
- group: the file group (defaults to ssh_group)
- directoryowner: the file parent directory owner  (defaults to ssh_owner)
- directorygroup: the file parent directory group (defaults to ssh_group)
