### PR TITLE
Handle a few deprecated OpenSSH options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ All tests will be reviewed internally for their validity and overall project dir
 
 ### Document your code
 
-As code is more often read than written, please provide documentation in all projects. 
+As code is more often read than written, please provide documentation in all projects.
 
 Adhere to the respective guidelines for documentation:
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,7 @@
 # config file for ansible -- http://ansible.com/
 # ==============================================
 
-# nearly all parameters can be overridden in ansible-playbook 
+# nearly all parameters can be overridden in ansible-playbook
 # or with command line flags. ansible will read ANSIBLE_CONFIG,
 # ansible.cfg in the current working directory, .ansible.cfg in
 # the home directory or /etc/ansible/ansible.cfg, whichever it

--- a/templates/openssh.conf.j2
+++ b/templates/openssh.conf.j2
@@ -82,7 +82,7 @@ ForwardX11 no
 
 # Never use host-based authentication. It can be exploited.
 HostbasedAuthentication no
-{% if sshd_version.stdout < 7.4 -%}
+{% if sshd_version.stdout | float < 7.4 -%}
 RhostsRSAAuthentication no
 # Enable RSA authentication via identity files.
 RSAAuthentication yes

--- a/templates/openssh.conf.j2
+++ b/templates/openssh.conf.j2
@@ -82,10 +82,11 @@ ForwardX11 no
 
 # Never use host-based authentication. It can be exploited.
 HostbasedAuthentication no
+{% if sshd_version.stdout < 7.4 -%}
 RhostsRSAAuthentication no
-
 # Enable RSA authentication via identity files.
 RSAAuthentication yes
+{% endif %}
 
 # Disable password-based authentication, it can allow for potentially easier brute-force attacks.
 PasswordAuthentication {{ 'yes' if ssh_client_password_login else 'no' }}

--- a/templates/openssh.conf.j2
+++ b/templates/openssh.conf.j2
@@ -111,5 +111,7 @@ Compression yes
 #EscapeChar ~
 #VisualHostKey yes
 
+{% if sshd_version.stdout | float <= 7.1 -%}
 # Disable experimental client roaming. This is known to cause potential issues with secrets being disclosed to malicious servers and defaults to being disabled.
 UseRoaming {{ 'yes' if ssh_client_roaming else 'no' }}
+{% endif %}

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -75,7 +75,9 @@ LogLevel VERBOSE
 # --------------
 
 # Secure Login directives.
+{% if sshd_version.stdout < 7.5 -%}
 UsePrivilegeSeparation {% if (ansible_distribution == 'Debian' and ansible_distribution_major_version <= '6') or (ansible_os_family in ['Oracle Linux', 'RedHat'] and ansible_distribution_major_version <= '6') -%}{{ssh_ps53}}{% else %}{{ssh_ps59}}{% endif %}
+{% endif %}
 
 LoginGraceTime 30s
 MaxAuthTries {{ssh_max_auth_retries}}

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -75,7 +75,7 @@ LogLevel VERBOSE
 # --------------
 
 # Secure Login directives.
-{% if sshd_version.stdout < 7.5 -%}
+{% if sshd_version.stdout | float  < 7.5 -%}
 UsePrivilegeSeparation {% if (ansible_distribution == 'Debian' and ansible_distribution_major_version <= '6') or (ansible_os_family in ['Oracle Linux', 'RedHat'] and ansible_distribution_major_version <= '6') -%}{{ssh_ps53}}{% else %}{{ssh_ps59}}{% endif %}
 {% endif %}
 


### PR DESCRIPTION
Resolves #151.

RhostsRSAAuthentication + RSAAuthentication is deprecated as of 7.4
UsePrivilegeSeparation is deprecated as of 7.5 (the daemon is now sandboxed on all modern OSes/platforms by default)