### PR TITLE
Implement disabling chroot for sftp

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_print_motd` | false | false to disable printing of the MOTD|
 |`ssh_print_last_log` | false | false to disable display of last login information|
 |`sftp_enabled` | false | true to enable sftp configuration|
+|`sftp_chroot` | true | false to disable chroot for sftp|
 |`sftp_chroot_dir` | /home/%u | change default sftp chroot location|
 |`ssh_client_roaming` | false | enable experimental client roaming|
 |`sshd_moduli_minimum` | 2048 | remove Diffie-Hellman parameters smaller than the defined size to mitigate logjam|

--- a/default_custom.yml
+++ b/default_custom.yml
@@ -46,6 +46,7 @@
     ssh_server_password_login: true
     ssh_server_weak_hmac: true
     sftp_enabled: true
+    sftp_chroot: true
     ssh_server_enabled: false
     ssh_server_match_group:
       - group: 'root'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -139,6 +139,9 @@ ssh_print_debian_banner: false # sshd (Debian OS family only)
 # true to enable sftp configuration
 sftp_enabled: false
 
+# false to disable sftp chroot
+sftp_chroot: true
+
 # change default sftp chroot location
 sftp_chroot_dir: /home/%u
 

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -229,7 +229,9 @@ Subsystem sftp internal-sftp -l INFO -f LOCAL6
 # These lines must appear at the *end* of sshd_config
 Match Group sftponly
     ForceCommand internal-sftp -l INFO -f LOCAL6
+{% if sftp_chroot %}
     ChrootDirectory {{ sftp_chroot_dir }}
+{% endif %}
     AllowTcpForwarding no
     AllowAgentForwarding no
     PasswordAuthentication no


### PR DESCRIPTION
By default enabled, of course, but give the option to disable sftp chrooting.

As to writing tests... are those pulled from the baseline repositories? Should I submit a PR, if even applicable, to baseline for this change?