### PR TITLE
Mozilla SSH Guidelines

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -183,6 +183,7 @@ ssh_macs_66_default:
   - umac-128-etm@openssh.com
   - hmac-sha2-512
   - hmac-sha2-256
+  - umac-128@openssh.com
 
 ssh_macs_76_default:
   - hmac-sha2-512-etm@openssh.com
@@ -218,6 +219,9 @@ ssh_kex_59_weak: "{{ ssh_kex_59_default + ['diffie-hellman-group14-sha1', 'diffi
 ssh_kex_66_default:
   - curve25519-sha256@libssh.org
   - diffie-hellman-group-exchange-sha256
+  - ecdh-sha2-nistp521
+  - ecdh-sha2-nistp384
+  - ecdh-sha2-nistp256
 
 ssh_kex_66_weak: "{{ ssh_kex_66_default + ['diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group1-sha1'] }}"
 


### PR DESCRIPTION
Following SSH guidelines from Mozilla https://infosec.mozilla.org/guidelines/openssh, the change adds and Mac and Key Exchange ciphers to get an A grade with the mozilla ssh_scan scanner. 

Tested on Ubuntu 16 with Openssh 7.2.