### PR TITLE
set 'GSSAPIAuthentication yes' if variable 'ssh_gssapi_support' is set to 'true'

### DIFF
--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -121,7 +121,7 @@ KerberosTicketCleanup yes
 
 {% if ssh_gssapi_support -%}
 # Only enable GSSAPI authentication if it is configured.
-GSSAPIAuthentication no
+GSSAPIAuthentication yes
 GSSAPICleanupCredentials yes
 {% endif %}
 


### PR DESCRIPTION
Should solve #192 

GSSAPIAuthentication should only be enabled in the sshd_config, not in the ssh_config - right?

If yes - everything should be alright.