### PR TITLE
added some macs & kex regarding Mozilla-recommendations

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -176,6 +176,7 @@ ssh_macs_66_default:
   - hmac-sha2-512-etm@openssh.com
   - hmac-sha2-256-etm@openssh.com
   - umac-128-etm@openssh.com
+  - umac-128@openssh.com
   - hmac-sha2-512
   - hmac-sha2-256
 
@@ -183,6 +184,7 @@ ssh_macs_76_default:
   - hmac-sha2-512-etm@openssh.com
   - hmac-sha2-256-etm@openssh.com
   - umac-128-etm@openssh.com
+  - umac-128@openssh.com
   - hmac-sha2-512
   - hmac-sha2-256
 
@@ -205,6 +207,9 @@ ssh_kex_59_default:
 ssh_kex_66_default:
   - curve25519-sha256@libssh.org
   - diffie-hellman-group-exchange-sha256
+  - ecdh-sha2-nistp521
+  - ecdh-sha2-nistp384
+  - ecdh-sha2-nistp256
 
 # directory where to store ssh_password policy
 ssh_custom_selinux_dir: '/etc/selinux/local-policies'


### PR DESCRIPTION
Mozilla has some Recommendations behind: https://infosec.mozilla.org/guidelines/openssh

To get an A-rating from their test: https://github.com/mozilla/ssh_scan and thus full compliance, we should add this options as well into this hardening-baseline.