### PR TITLE
Added vars for Sangoma FreePBX Linux (Copied from Red Hat)

### DIFF
--- a/vars/Sangoma.yml
+++ b/vars/Sangoma.yml
@@ -1,0 +1,3 @@
+sshd_service_name: sshd
+ssh_owner: root
+ssh_group: root


### PR DESCRIPTION
Sangoma FreePBX is a free user-interface around asterisk. It is running on a RHEL clone, so I copied the redhat configuration for Sangoma.