### PR TITLE
fix: allow other ssh ports using selinux

### DIFF
--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -71,13 +71,6 @@
     - ssh_challengeresponseauthentication
     - ssh_google_auth
 
-- name: test to see if selinux is installed and running
-  command: getenforce
-  register: sestatus
-  failed_when: false
-  changed_when: false
-  check_mode: no
-
 - name: include selinux specific tasks
   include_tasks: selinux.yml
-  when: sestatus.rc == 0
+  when: ansible_selinux and ansible_selinux.status != "disabled"

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -14,6 +14,15 @@
     state: present
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
+- name: "authorize {{ ssh_server_ports }} ports for selinux"
+  seport:
+    ports: '{{ item }}'
+    proto: tcp
+    setype: ssh_port_t
+    state: present
+  with_items:
+    - "{{ ssh_server_ports }}"
+
 - name: check if ssh_password module is already installed
   shell: 'set -o pipefail && semodule -l | grep ssh_password'
   args:
@@ -48,7 +57,7 @@
   - name: install selinux policy
     command: semodule -i {{ ssh_custom_selinux_dir }}/ssh_password.pp
 
-  when: not ssh_use_pam and sestatus.stdout != 'Disabled' and ssh_password_module.stdout.find('ssh_password') != 0
+  when: not ssh_use_pam and ansible_selinux != 'Disabled' and ssh_password_module.stdout.find('ssh_password') != 0
 
 # The following tasks only get executed when selinux is installed, UsePam is 'yes' and the ssh_password module is installed.
 # See http://danwalsh.livejournal.com/12333.html for more info


### PR DESCRIPTION
Hi there 🙃

I encountered the same issue as described on #212. Whereas I don’t think tweaking the firewalld is a good idea because it adds dependencies, we should consider allowing ssh ports on SELinux policy if they differ from the default values.