### PR TITLE
Fix squash_actions deprecation in test playbooks

### DIFF
--- a/tests/default.yml
+++ b/tests/default.yml
@@ -8,10 +8,11 @@
         - "openssh-server"
         - "libselinux-python"
       ignore_errors: true
-    - apt: name="{{item}}" state=present update_cache=true
-      with_items:
-        - "openssh-client"
-        - "openssh-server"
+    - apt: name="{{packages}}" state=present update_cache=true
+      vars:
+        packages:
+          - "openssh-client"
+          - "openssh-server"
       ignore_errors: true
     - file: path="/var/run/sshd" state=directory
     - name: create ssh host keys

--- a/tests/default_custom.yml
+++ b/tests/default_custom.yml
@@ -8,10 +8,11 @@
         - "openssh-server"
         - "libselinux-python"
       ignore_errors: true
-    - apt: name="{{item}}" state=present update_cache=true
-      with_items:
-        - "openssh-client"
-        - "openssh-server"
+    - apt: name="{{packages}}" state=present update_cache=true
+      vars:
+        packages:
+          - "openssh-client"
+          - "openssh-server"
       ignore_errors: true
     - file: path="/var/run/sshd" state=directory
     - name: create ssh host keys


### PR DESCRIPTION
This PR fixes the following deprecation warnings in test playbooks:
`[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying 'name: "{{item}}"', please use 'name: ['openssh-client', 'openssh-server']' and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.`