### PR TITLE
changed string comparison to version comparison

### DIFF
--- a/tasks/crypto.yml
+++ b/tasks/crypto.yml
@@ -3,60 +3,60 @@
 - name: set hostkeys according to openssh-version
   set_fact:
     ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key']
-  when: sshd_version.stdout >= '6.3' and not ssh_host_key_files
+  when: sshd_version.stdout is version('6.3', '>=') and not ssh_host_key_files
 
 - name: set hostkeys according to openssh-version
   set_fact:
     ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key']
-  when: sshd_version.stdout >= '6.0' and not ssh_host_key_files
+  when: sshd_version.stdout is version('6.0', '>=') and not ssh_host_key_files
 
 - name: set hostkeys according to openssh-version
   set_fact:
     ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key']
-  when: sshd_version.stdout >= '5.3' and not ssh_host_key_files
+  when: sshd_version.stdout is version('5.3', '>=') and not ssh_host_key_files
 
 ###
 
 - name: set macs according to openssh-version if openssh >= 7.6
   set_fact:
     ssh_macs: '{{ ssh_macs_76_default }}'
-  when: sshd_version.stdout >= '7.6' and not ssh_macs
+  when: sshd_version.stdout is version('7.6', '>=') and not ssh_macs
 
 - name: set macs according to openssh-version if openssh >= 6.6
   set_fact:
     ssh_macs: '{{ ssh_macs_66_default }}'
-  when: sshd_version.stdout >= '6.6' and not ssh_macs
+  when: sshd_version.stdout is version('6.6', '>=') and not ssh_macs
 
 - name: set macs according to openssh-version
   set_fact:
     ssh_macs: '{{ ssh_macs_59_default }}'
-  when: sshd_version.stdout >= '5.9' and not ssh_macs
+  when: sshd_version.stdout is version('5.9', '>=') and not ssh_macs
 
 - name: set macs according to openssh-version
   set_fact:
     ssh_macs: '{{ ssh_macs_53_default }}'
-  when: sshd_version.stdout >= '5.3' and not ssh_macs
+  when: sshd_version.stdout is version('5.3', '>=') and not ssh_macs
 
 ###
 
 - name: set ciphers according to openssh-version if openssh >= 6.6
   set_fact:
     ssh_ciphers: '{{ ssh_ciphers_66_default }}'
-  when: sshd_version.stdout >= '6.6' and not ssh_ciphers
+  when: sshd_version.stdout is version('6.6', '>=') and not ssh_ciphers
 
 - name: set ciphers according to openssh-version
   set_fact:
     ssh_ciphers: '{{ ssh_ciphers_53_default }}'
-  when: sshd_version.stdout >= '5.3' and not ssh_ciphers
+  when: sshd_version.stdout is version('5.3', '>=') and not ssh_ciphers
 
 ###
 
 - name: set kex according to openssh-version if openssh >= 6.6
   set_fact:
     ssh_kex: '{{ ssh_kex_66_default }}'
-  when: sshd_version.stdout >= '6.6' and not ssh_kex
+  when: sshd_version.stdout is version('6.6', '>=') and not ssh_kex
 
 - name: set kex according to openssh-version
   set_fact:
     ssh_kex: '{{ ssh_kex_59_default }}'
-  when: sshd_version.stdout >= '5.9' and not ssh_kex
+  when: sshd_version.stdout is version('5.9', '>=') and not ssh_kex


### PR DESCRIPTION
Description: Changed sshd_version string comparison to version comparison.
refer:[](https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#version-comparison)
Problem with string comparison for version comparison (just for example): If sshd_version.stdout is 6.10 and you try to compare it with 6.3 (like '6.10' > '6.3'), it would result in false.

Signed-off-by: Gobind Singh <gobindsingh108@gmail.com>