### PR TITLE
sshd_config RevokedKeys version limit

### DIFF
--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -229,7 +229,7 @@ Banner {{ '/etc/ssh/banner.txt' if (ssh_banner|bool) else 'none' }}
 DebianBanner {{ 'yes' if (ssh_print_debian_banner|bool) else 'no' }}
 {% endif %}
 
-{% if sshd_version.stdout is version('5.4', '>') %}
+{% if sshd_version.stdout is version('5.4', '>=') %}
 # Reject keys that are explicitly blacklisted
 RevokedKeys /etc/ssh/revoked_keys
 {% endif %}

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -229,8 +229,10 @@ Banner {{ '/etc/ssh/banner.txt' if (ssh_banner|bool) else 'none' }}
 DebianBanner {{ 'yes' if (ssh_print_debian_banner|bool) else 'no' }}
 {% endif %}
 
+{% if sshd_version.stdout is version('5.4', '>') %}
 # Reject keys that are explicitly blacklisted
 RevokedKeys /etc/ssh/revoked_keys
+{% endif %}
 
 {% if sftp_enabled -%}
 # SFTP matching configuration


### PR DESCRIPTION
The sshd_config option RevokedKeys was introduced in OpenSSH version 5.4. All versions before does not support this option.
https://www.openssh.com/releasenotes.html