### PR TITLE
DebianBanner introduced in Debian OpenSSH 5.2

### DIFF
--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -225,7 +225,7 @@ PrintLastLog {{ 'yes' if (ssh_print_last_log|bool) else 'no' }}
 
 Banner {{ '/etc/ssh/banner.txt' if (ssh_banner|bool) else 'none' }}
 
-{% if ansible_os_family == 'Debian' -%}
+{% if (ansible_os_family == 'Debian' and sshd_version.stdout is version('5.2', '>=')) -%}
 DebianBanner {{ 'yes' if (ssh_print_debian_banner|bool) else 'no' }}
 {% endif %}
 

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -225,7 +225,7 @@ PrintLastLog {{ 'yes' if (ssh_print_last_log|bool) else 'no' }}
 
 Banner {{ '/etc/ssh/banner.txt' if (ssh_banner|bool) else 'none' }}
 
-{% if (ansible_os_family == 'Debian' and sshd_version.stdout is version('5.2', '>=')) -%}
+{% if ansible_os_family == 'Debian' and sshd_version.stdout is version('5.2', '>=') -%}
 DebianBanner {{ 'yes' if (ssh_print_debian_banner|bool) else 'no' }}
 {% endif %}
 


### PR DESCRIPTION
The sshd_config option DebianBanner was added in version OpenSSH 5.2p1-2. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=562048

If distribution family is Debian and ssh version is greater than or equal to 5.2, the DebianBanner option will be written into the configuration file by the template.