### PR TITLE
UseRoaming option exist between openSSH 5.4 and 7.1

### DIFF
--- a/templates/openssh.conf.j2
+++ b/templates/openssh.conf.j2
@@ -119,7 +119,7 @@ Compression yes
 #EscapeChar ~
 #VisualHostKey yes
 
-{% if sshd_version.stdout is version('7.1', '<=') %}
+{% if sshd_version.stdout is version('5.4', '>=') and sshd_version.stdout is version('7.1', '<=') %}
 # Disable experimental client roaming. This is known to cause potential issues with secrets being disclosed to malicious servers and defaults to being disabled.
 UseRoaming {{ 'yes' if ssh_client_roaming else 'no' }}
 {% endif %}


### PR DESCRIPTION
All OpenSSH versions between 5.4 and 7.1 have the undocumented option UseRoaming.

If ssh version is greater than or equal to 5.4 and lower than or equal to 7.1, the UseRoaming option will be written into the configuration file by the template.