### PR TITLE
RHEL/OL/CentOS 8 support

### DIFF
--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -1,18 +1,8 @@
 ---
-- name: install selinux dependencies when selinux is installed on RHEL or Oracle Linux
+- name: install selinux dependencies when selinux is installed
   package:
-    name: '{{ item }}'
+    name: '{{ ssh_selinux_packages }}'
     state: present
-  with_items:
-    - 'policycoreutils-python'
-    - 'checkpolicy'
-  when: ansible_os_family == 'RedHat' or ansible_os_family == 'Oracle Linux'
-
-- name: install selinux dependencies when selinux is installed on Debian or Ubuntu
-  apt:
-    name: ['policycoreutils', 'checkpolicy']
-    state: present
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: "authorize {{ ssh_server_ports }} ports for selinux"
   seport:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,6 @@
 sshd_service_name: ssh
 ssh_owner: root
 ssh_group: root
+ssh_selinux_packages:
+  - policycoreutils-python
+  - checkpolicy

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -2,5 +2,5 @@ sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root
 ssh_selinux_packages:
-  - policycoreutils-python
+  - python3-policycoreutils
   - checkpolicy

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,3 +1,6 @@
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root
+ssh_selinux_packages:
+  - policycoreutils-python
+  - checkpolicy

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -2,5 +2,5 @@ sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root
 ssh_selinux_packages:
-  - policycoreutils-python
+  - python3-policycoreutils
   - checkpolicy


### PR DESCRIPTION
RHEL 8 only supports python3, therefore the the package for policycoreutils-module changed.
This commit reflects that change and installs a different package depending on the major release.