### PR TITLE
Fix typo in openssh-client package

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ bundle exec kitchen test
 # for development
 bundle exec kitchen create ssh-ubuntu1804-ansible-latest
 bundle exec kitchen converge ssh-ubuntu1804-ansible-latest
+bundle exec kitchen verify ssh-ubuntu1804-ansible-latest
+
+# cleanup
+bundle exec kitchen destroy ssh-ubuntu1804-ansible-latest
 ```
 
 ### Testing with Virtualbox
@@ -143,6 +147,8 @@ KITCHEN_YAML=".kitchen.vagrant.yml" bundle exec kitchen create ssh-ubuntu-1804
 KITCHEN_YAML=".kitchen.vagrant.yml" bundle exec kitchen converge ssh-ubuntu-1804
 ```
 For more information see [test-kitchen](http://kitchen.ci/docs/getting-started)
+
+
 
 ## FAQ / Pitfalls
 

--- a/tests/default.yml
+++ b/tests/default.yml
@@ -4,7 +4,7 @@
   pre_tasks:
     - package: name="{{item}}" state=present
       with_items:
-        - "openssh-clients"
+        - "openssh-client"
         - "openssh-server"
         - "libselinux-python"
       ignore_errors: true

--- a/tests/default.yml
+++ b/tests/default.yml
@@ -6,7 +6,7 @@
       with_items:
         - "openssh-client"
         - "openssh-server"
-        - "libselinux-python"
+        - "python-selinux"
       ignore_errors: true
     - apt: name="{{packages}}" state=present update_cache=true
       vars:


### PR DESCRIPTION
Running kitchen locally, e.g. executing `bundle exec kitchen test ssh-ubuntu1804-ansible-late` results into executing the tests/default.yml playbook.

In the console you can see the following error message:

```
PLAY [wrapper playbook for kitchen testing "ansible-ssh-hardening" with default settings] ***

       TASK [Gathering Facts] *********************************************************
       ok: [localhost]

       TASK [package] *****************************************************************
        [WARNING]: Could not find aptitude. Using apt-get instead

       failed: [localhost] (item=openssh-clients) => {"ansible_loop_var": "item", "changed": false, "item": "openssh-clients", "msg": "No package matching 'openssh-clients' is available"}
       ok: [localhost] => (item=openssh-server) => {"ansible_loop_var": "item", "cache_update_time": 1570037306, "cache_updated": false, "changed": false, "item": "openssh-server", "warnings
": ["Could not find aptitude. Using apt-get instead"]}
       ...ignoring
```

There is a typo in the package name.
