### PR TITLE
Add Testsupport for centos 8

### DIFF
--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -33,6 +33,9 @@ platforms:
 - name: centos-7
   driver_config:
     box: bento/centos-7
+- name: centos-8
+  driver_config:
+    box: bento/centos-8
 - name: oracle-6
   driver_config:
     box: bento/oracle-6

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,6 +36,14 @@ platforms:
     provision_command:
       - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
       - systemctl enable sshd.service
+- name: centos8-ansible-latest
+  driver:
+    image: rndmh3ro/docker-centos8-ansible:latest
+    platform: centos
+    run_command: /sbin/init
+    provision_command:
+      - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
+      - systemctl enable sshd.service
 - name: oracle6-ansible-latest
   driver:
     image: rndmh3ro/docker-oracle6-ansible:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ env:
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     version: latest
 
+  - distro: centos8
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    version: latest
+
   - distro: oracle6
     version: latest
     init: /sbin/init

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
       versions:
         - 6
         - 7
+        - 8
     - name: Ubuntu
       versions:
         - xenial


### PR DESCRIPTION
This PR adds support for testing centos 8.  

Please note that the vagrant box has not been published yet.  
We should wait with merging this until then.

Closes https://github.com/dev-sec/ansible-ssh-hardening/issues/247