### PR TITLE
add variable to set PubkeyAcceptedKeyTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_custom_options` | [] | Custom lines for SSH client configuration |
 |`sshd_custom_options` | [] | Custom lines for SSH daemon configuration |
 |`sshd_syslog_facility` | 'AUTH' | The facility code that is used when logging messages from sshd |
-|`sshd_log_level` | 'VERBOSE' | the verbosity level that is used when logging messages from sshd | 
+|`sshd_log_level` | 'VERBOSE' | the verbosity level that is used when logging messages from sshd |
 |`sshd_strict_modes` | 'yes' | Check file modes and ownership of the user's files and home directory before accepting login |
-|`sshd_authenticationmethods` | `publickey` | Specifies the authentication methods that must be successfully completed for a user to be granted access. Make sure to set all required variables for your selected authentication method. Defaults found in `defaults/main.yml`
+|`sshd_authenticationmethods` | `publickey` | Specifies the authentication methods that must be successfully completed for a user to be granted access. Make sure to set all required variables for your selected authentication method. Defaults found in `defaults/main.yml` |
+|`ssh_pubkeyacceptedkeytypes` | [] | Specifies the public key types accepted for ssh client |
+|`sshd_pubkeyacceptedkeytypes` | [] | Specifies the public key types accepted for sshd server
 
 ## Configuring settings not listed in role-variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,6 +70,10 @@ ssh_use_pam: true # sshd
 # specify AuthenticationMethods
 sshd_authenticationmethods: 'publickey'
 
+# specify PubkeyAcceptedKeyTypes
+ssh_pubkeyacceptedkeytypes: []
+sshd_pubkeyacceptedkeytypes: []
+
 # true if SSH support GSSAPI
 ssh_gssapi_support: false
 

--- a/templates/openssh.conf.j2
+++ b/templates/openssh.conf.j2
@@ -82,6 +82,9 @@ StrictHostKeyChecking ask
 {# This outputs "KexAlgorithms <list-of-algos>" if ssh_kex is defined or "#KexAlgorithms" if ssh_kex is undefined #}
 {{ "KexAlgorithms "+ssh_kex| join(',') if ssh_kex else "KexAlgorithms"|comment }}
 
+{# This outpus "PubkeyAcceptedKeyTypes <list-of-key-types>" if ssh_pubkeyacceptedkeytypes is defined #}
+{{ "PubkeyAcceptedKeyTypes "+ ssh_pubkeyacceptedkeytypes|join(',') if ssh_pubkeyacceptedkeytypes else "PubkeyAcceptedKeyTypes"|comment }}
+
 # Disable agent forwarding, since local agent could be accessed through forwarded connection.
 ForwardAgent no
 

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -97,6 +97,8 @@ MaxStartups {{ssh_max_startups}}
 
 # Enable public key authentication
 PubkeyAuthentication yes
+{# This outpus "PubkeyAcceptedKeyTypes <list-of-key-types>" if sshd_pubkeyacceptedkeytypes is defined #}
+{{ "PubkeyAcceptedKeyTypes "+ sshd_pubkeyacceptedkeytypes|join(',') if sshd_pubkeyacceptedkeytypes else "PubkeyAcceptedKeyTypes"|comment }}
 
 # Never use host-based authentication. It can be exploited.
 IgnoreRhosts yes


### PR DESCRIPTION
Sometimes we need to specify allowed public key types that are accepted by both server and client, and the list can be different on both.

Thank you.