### PR TITLE
Support KEX for OpenSSH 8.0+ & quantum resistant KEX

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -209,6 +209,11 @@ ssh_kex_59_default:
 ssh_kex_66_default:
   - curve25519-sha256@libssh.org
   - diffie-hellman-group-exchange-sha256
+  
+ssh_kex_80_default:
+  - sntrup4591761x25519-sha512@tinyssh.org
+  - curve25519-sha256@libssh.org
+  - diffie-hellman-group-exchange-sha256
 
 # directory where to store ssh_password policy
 ssh_custom_selinux_dir: '/etc/selinux/local-policies'

--- a/tasks/crypto.yml
+++ b/tasks/crypto.yml
@@ -51,6 +51,11 @@
 
 ###
 
+- name: set kex according to openssh-version if openssh >= 8.0
+  set_fact:
+    ssh_kex: '{{ ssh_kex_80_default }}'
+  when: sshd_version.stdout is version('8.0', '>=') and not ssh_kex
+
 - name: set kex according to openssh-version if openssh >= 6.6
   set_fact:
     ssh_kex: '{{ ssh_kex_66_default }}'


### PR DESCRIPTION
This will support the quantum resistant KEX method released with OpenSSH 8.0 https://codesmithdev.com/openssh-8-0-releasing-with-quantum-computing-resistant-keys/