### PR TITLE
Add 'all', 'local', 'yes', 'no' options support for AllowTcpForwarding variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_permit_tunnel` | false | true if SSH Port Tunneling is required |
 |`ssh_remote_hosts` | [] | one or more hosts and their custom options for the ssh-client. Default is empty. See examples in `defaults/main.yml`.|
 |`ssh_permit_root_login` | no | Disable root-login. Set to `without-password` or `yes` to enable root-login |
-|`ssh_allow_tcp_forwarding` | false | false to disable TCP Forwarding. Set to true to allow TCP Forwarding.|
+|`ssh_allow_tcp_forwarding` | false | false to disable TCP Forwarding. Set to true to allow TCP Forwarding. If you are using OpenSSH >= 6.2 version, you should specify `yes`, `no`, `all` or `local` otherwise it will fallback to default value|
 |`ssh_gateway_ports` | `false` | `false` to disable binding forwarded ports to non-loopback addresses. Set to `true` to force binding on wildcard address. Set to `clientspecified` to allow the client to specify which address to bind to.|
 |`ssh_allow_agent_forwarding` | false | false to disable Agent Forwarding. Set to true to allow Agent Forwarding.|
 |`ssh_pam_support` | true | true if SSH has PAM support.|

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_permit_tunnel` | false | true if SSH Port Tunneling is required |
 |`ssh_remote_hosts` | [] | one or more hosts and their custom options for the ssh-client. Default is empty. See examples in `defaults/main.yml`.|
 |`ssh_permit_root_login` | no | Disable root-login. Set to `without-password` or `yes` to enable root-login |
-|`ssh_allow_tcp_forwarding` | false | false to disable TCP Forwarding. Set to true to allow TCP Forwarding. If you are using OpenSSH >= 6.2 version, you should specify `yes`, `no`, `all` or `local` otherwise it will fallback to default value|
+|`ssh_allow_tcp_forwarding` | no | `no` to disable TCP Forwarding. Set to `yes` to allow TCP Forwarding. If you are using OpenSSH >= 6.2 version, you can specify `yes`, `no`, `all` or `local`|
 |`ssh_gateway_ports` | `false` | `false` to disable binding forwarded ports to non-loopback addresses. Set to `true` to force binding on wildcard address. Set to `clientspecified` to allow the client to specify which address to bind to.|
 |`ssh_allow_agent_forwarding` | false | false to disable Agent Forwarding. Set to true to allow Agent Forwarding.|
 |`ssh_pam_support` | true | true if SSH has PAM support.|

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,7 +52,7 @@ ssh_remote_hosts: []
 ssh_permit_root_login: 'no'          # sshd
 
 # false to disable TCP Forwarding. Set to true to allow TCP Forwarding.
-ssh_allow_tcp_forwarding: false         # sshd
+ssh_allow_tcp_forwarding: 'no'        # sshd
 
 # false to disable binding forwarded ports to non-loopback addresses. Set to true to force binding on wildcard address.
 # Set to 'clientspecified' to allow the client to specify which address to bind to.

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -177,7 +177,7 @@ PermitTunnel {{ 'yes' if (ssh_permit_tunnel|bool) else 'no' }}
 {% if sshd_version.stdout is version('6.2', '>=') %}
 AllowTcpForwarding {{ ssh_allow_tcp_forwarding if (ssh_allow_tcp_forwarding in ('yes', 'no', 'local', 'all')) else 'no' }}
 {% else %}
-AllowTcpForwarding {{ 'yes' if (ssh_allow_tcp_forwarding|bool) else 'no' }}
+AllowTcpForwarding {{ ssh_allow_tcp_forwarding if (ssh_allow_tcp_forwarding in ('yes', 'no')) else 'no' }}
 {% endif %}
 
 # Disable agent forwarding, since local agent could be accessed through forwarded connection.

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -174,7 +174,11 @@ PermitTunnel {{ 'yes' if (ssh_permit_tunnel|bool) else 'no' }}
 
 # Disable forwarding tcp connections.
 # no real advantage without denied shell access
+{% if sshd_version.stdout is version('6.2', '>=') %}
+AllowTcpForwarding {{ ssh_allow_tcp_forwarding if (ssh_allow_tcp_forwarding in ('yes', 'no', 'local', 'all')) else 'no' }}
+{% else %}
 AllowTcpForwarding {{ 'yes' if (ssh_allow_tcp_forwarding|bool) else 'no' }}
+{% endif %}
 
 # Disable agent forwarding, since local agent could be accessed through forwarded connection.
 # no real advantage without denied shell access

--- a/tests/default_custom.yml
+++ b/tests/default_custom.yml
@@ -23,7 +23,7 @@
     - ansible-ssh-hardening
   vars:
     network_ipv6_enable: true
-    ssh_allow_tcp_forwarding: 'local'
+    ssh_allow_tcp_forwarding: 'yes'
     ssh_gateway_ports: true
     ssh_allow_agent_forwarding: true
     ssh_server_permit_environment_vars: 'yes'

--- a/tests/default_custom.yml
+++ b/tests/default_custom.yml
@@ -23,7 +23,7 @@
     - ansible-ssh-hardening
   vars:
     network_ipv6_enable: true
-    ssh_allow_tcp_forwarding: true
+    ssh_allow_tcp_forwarding: 'local'
     ssh_gateway_ports: true
     ssh_allow_agent_forwarding: true
     ssh_server_permit_environment_vars: 'yes'


### PR DESCRIPTION
This PR is a result of a feature request #255 

I guess this requires a discussion since I've decided to support both ways to maintain backwards compatibility. 

IMHO we should drop boolean and only support string values