### PR TITLE
Add support for AuthorizedKeysCommand configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,6 +73,9 @@ sshd_authenticationmethods: 'publickey'
 # true if SSH support GSSAPI
 ssh_gssapi_support: false
 
+# Use an external script or executable to get authorized keys. Always run as user nobody
+ssh_authorized_keys_command: '' # sshd
+
 # true if SSH support Kerberos
 ssh_kerberos_support: true
 

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -131,6 +131,11 @@ KerberosTicketCleanup yes
 GSSAPIAuthentication {{ 'yes' if ssh_gssapi_support else 'no' }}
 GSSAPICleanupCredentials yes
 
+{% if ssh_authorized_keys_command -%}
+AuthorizedKeysCommand {{ ssh_authorized_keys_command }}
+AuthorizedKeysCommandUser nobody
+{% endif %}
+
 # In case you don't use PAM (`UsePAM no`), you can alternatively restrict users and groups here. For key-based authentication this is not necessary, since all keys must be explicitely enabled.
 {% if ssh_deny_users -%}
 DenyUsers {{ssh_deny_users}}


### PR DESCRIPTION
Adds optional variable for configuring a AuthorizedKeysCommand such as sss_ssh_authorizedkeys. The configured command is always run as the user nobody.