### PR TITLE
Reinstating the `ssh_google_auth`-variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_challengeresponseauthentication` | false | Specifies whether challenge-response authentication is allowed (e.g. via PAM) |
 |`ssh_client_password_login` | false | `true` to allow password-based authentication with the ssh client |
 |`ssh_server_password_login` | false | `true` to allow password-based authentication with the ssh server |
+|`ssh_google_auth` | false | `true` to enable google authenticator based TOTP 2FA |
 |`ssh_banner` | `false` | `true` to print a banner on login |
 |`ssh_client_hardening` | `true` | `false` to stop harden the client |
 |`ssh_client_port` | `'22'` | Specifies the port number to connect on the remote host. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,9 @@ ssh_pam_support: true
 # false to disable pam authentication.
 ssh_use_pam: true # sshd
 
+# false to disable google 2fa authentication
+ssh_google_auth: false                  # sshd
+
 # specify AuthenticationMethods
 sshd_authenticationmethods: 'publickey'
 

--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -69,6 +69,7 @@
   when:
     - ssh_use_pam | bool
     - ssh_challengeresponseauthentication | bool
+    - ssh_google_auth | bool
 
 - name: include selinux specific tasks
   include_tasks: selinux.yml


### PR DESCRIPTION
This was removed in bea269a7ffa50eae3ad325a6749fc2e7435b97b2. Just because I use pam, and challenge response authentication, does not mean I wish to install `libpam-google-authenticator`.