### PR TITLE
Refactor loading of OS dependent variables 

### DIFF
--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -1,13 +1,15 @@
 ---
 - name: Set OS dependent variables
-  include_vars: '{{ item }}'
-  with_first_found:
-   - files:
-     - '{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml'
-     - '{{ ansible_distribution }}.yml'
-     - '{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml'
-     - '{{ ansible_os_family }}.yml'
-   - skip: True
+  include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_major_version| default('none') }}.yml"
+        - "{{ ansible_facts.distribution }}.yml"
+        - "{{ ansible_facts.os_family }}-{{ ansible_facts.distribution_major_version| default('none') }}.yml"
+      paths:
+        - "vars"
+  tags: always
 
 - name: get openssh-version
   shell: set -o pipefail && ssh -V 2>&1 | sed -r 's/.*_([0-9]*\.[0-9]).*/\1/g'

--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -2,10 +2,12 @@
 - name: Set OS dependent variables
   include_vars: '{{ item }}'
   with_first_found:
-   - '{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml'
-   - '{{ ansible_distribution }}.yml'
-   - '{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml'
-   - '{{ ansible_os_family }}.yml'
+   - files:
+     - '{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml'
+     - '{{ ansible_distribution }}.yml'
+     - '{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml'
+     - '{{ ansible_os_family }}.yml'
+   - skip: True
 
 - name: get openssh-version
   shell: set -o pipefail && ssh -V 2>&1 | sed -r 's/.*_([0-9]*\.[0-9]).*/\1/g'


### PR DESCRIPTION
Otherwise, ansible with throw the following error if no file is
found:

```
fatal: [hydrogen]: FAILED! => {
    "msg": "No file was found when using with_first_found. Use the 'skip: true' option to allow this task to be skipped if no files are found"
}
```

In my case, I have no extra variables to add. See https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/lookup/first_found.py for more details on the [poorly named] `skip` option. It doesn't actually skip. Instead, it causes the task to "[r]eturn an empty list if no file is found, instead of an error."