### PR TITLE
Renaming Ansible variables discovered from systems

### DIFF
--- a/tasks/2fa.yml
+++ b/tasks/2fa.yml
@@ -4,13 +4,13 @@
   apt:
     name: 'libpam-google-authenticator'
     state: present
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  when: ansible_facts.distribution == 'Debian' or ansible_facts.distribution == 'Ubuntu'
 
 - name: Install google authenticator PAM module
   yum:
     name: 'google-authenticator'
     state: present
-  when: ansible_os_family == 'RedHat' or ansible_os_family == 'Oracle Linux'
+  when: ansible_facts.os_family == 'RedHat' or ansible_facts.os_family == 'Oracle Linux'
 
 - name: Add google auth module to PAM
   pamd:
@@ -26,11 +26,11 @@
     control: 'substack'
     module_path: 'password-auth'
     state: absent
-  when: ansible_distribution == 'RedHat' or ansible_distribution == 'Oracle Linux' or ansible_distribution == 'Amazon'
+  when: ansible_facts.distribution == 'RedHat' or ansible_facts.distribution == 'Oracle Linux' or ansible_facts.distribution == 'Amazon'
 
 - name: Remove password auth from PAM
   replace:
     dest: '/etc/pam.d/sshd'
     regexp: '^@include common-auth'
     replace: '#@include common-auth'
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  when: ansible_facts.distribution == 'Debian' or ansible_facts.distribution == 'Ubuntu'

--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -2,10 +2,10 @@
 - name: Set OS dependent variables
   include_vars: '{{ item }}'
   with_first_found:
-   - '{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml'
-   - '{{ ansible_distribution }}.yml'
-   - '{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml'
-   - '{{ ansible_os_family }}.yml'
+   - '{{ ansible_facts.distribution }}_{{ ansible_facts.distribution_major_version }}.yml'
+   - '{{ ansible_facts.distribution }}.yml'
+   - '{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version }}.yml'
+   - '{{ ansible_facts.os_family }}.yml'
 
 - name: get openssh-version
   command: ssh -V

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -87,7 +87,7 @@ LogLevel {{ sshd_log_level }}
 UseLogin no
 {% endif %}
 {% if sshd_version is version('7.5', '<') %}
-UsePrivilegeSeparation {% if (ansible_distribution == 'Debian' and ansible_distribution_major_version <= '6') or (ansible_os_family in ['Oracle Linux', 'RedHat'] and ansible_distribution_major_version <= '6') -%}{{ssh_ps53}}{% else %}{{ssh_ps59}}{% endif %}
+UsePrivilegeSeparation {% if (ansible_facts.distribution == 'Debian' and ansible_facts.distribution_major_version <= '6') or (ansible_facts.os_family in ['Oracle Linux', 'RedHat'] and ansible_facts.distribution_major_version <= '6') -%}{{ssh_ps53}}{% else %}{{ssh_ps59}}{% endif %}
 {% endif %}
 
 LoginGraceTime 30s
@@ -217,13 +217,13 @@ UseDNS {{ 'yes' if (ssh_use_dns|bool) else 'no' }}
 
 PrintMotd {{ 'yes' if (ssh_print_motd|bool) else 'no' }}
 
-{% if ansible_os_family != 'FreeBSD' %}
+{% if ansible_facts.os_family != 'FreeBSD' %}
 PrintLastLog {{ 'yes' if (ssh_print_last_log|bool) else 'no' }}
 {% endif %}
 
 Banner {{ '/etc/ssh/banner.txt' if (ssh_banner|bool) else 'none' }}
 
-{% if ansible_os_family == 'Debian' -%}
+{% if ansible_facts.os_family == 'Debian' -%}
 DebianBanner {{ 'yes' if (ssh_print_debian_banner|bool) else 'no' }}
 {% endif %}
 

--- a/tests/default.yml
+++ b/tests/default.yml
@@ -17,7 +17,7 @@
     - file: path="/var/run/sshd" state=directory
     - name: create ssh host keys
       command: "ssh-keygen -A"
-      when: not ((ansible_os_family in ['Oracle Linux', 'RedHat']) and ansible_distribution_major_version < '7') or ansible_distribution == "Fedora"
+      when: not ((ansible_facts.os_family in ['Oracle Linux', 'RedHat']) and ansible_facts.distribution_major_version < '7') or ansible_facts.distribution == "Fedora"
 
   roles:
     - ansible-ssh-hardening

--- a/tests/default_custom.yml
+++ b/tests/default_custom.yml
@@ -17,7 +17,7 @@
     - file: path="/var/run/sshd" state=directory
     - name: create ssh host keys
       command: "ssh-keygen -A"
-      when: not ((ansible_os_family in ['Oracle Linux', 'RedHat']) and ansible_distribution_major_version < '7') or ansible_distribution == "Fedora"
+      when: not ((ansible_facts.os_family in ['Oracle Linux', 'RedHat']) and ansible_facts.distribution_major_version < '7') or ansible_facts.distribution == "Fedora"
 
   roles:
     - ansible-ssh-hardening


### PR DESCRIPTION
Renaming ansible variables discovered from `systems: Facts` to be placed in new namespace ansible_facts.*
According to Ansible documentation system discovered variables have now their own namespace - `ansible_facts.*` This was introduced in Ansible version 2.5. Variables that are being gathered as facts and written to old main namespace will be deprecated in future releases. 
https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html#ansible-fact-namespacing
Since the requirements say that we should use Ansible > 2.5, variables should be changed.