### PR TITLE
Use sha2 HMACs on RHEL 6 / CentOS 6.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -171,6 +171,10 @@ ssh_macs_53_default:
   - hmac-ripemd160
   - hmac-sha1
 
+ssh_macs_53_el_6_5_default:
+  - hmac-sha2-512
+  - hmac-sha2-256
+
 ssh_macs_59_default:
   - hmac-sha2-512
   - hmac-sha2-256

--- a/tasks/crypto.yml
+++ b/tasks/crypto.yml
@@ -36,7 +36,7 @@
   set_fact:
     ssh_macs: '{{ ssh_macs_53_el_6_5_default }}'
   when:
-    - ansible_distribution in ['CentOS', 'RedHat']
+    - ansible_distribution in ['CentOS', 'OracleLinux', 'RedHat']
     - ansible_distribution_version is version('6.5', '>=')
     - not ssh_macs
 

--- a/tasks/crypto.yml
+++ b/tasks/crypto.yml
@@ -32,6 +32,14 @@
     ssh_macs: '{{ ssh_macs_59_default }}'
   when: sshd_version is version('5.9', '>=') and not ssh_macs
 
+- name: set macs for Enterprise Linux >= 6.5 (openssh 5.3 with backports)
+  set_fact:
+    ssh_macs: '{{ ssh_macs_53_el_6_5_default }}'
+  when:
+    - ansible_distribution in ['CentOS', 'RedHat']
+    - ansible_distribution_version is version('6.5', '>=')
+    - not ssh_macs
+
 - name: set macs according to openssh-version
   set_fact:
     ssh_macs: '{{ ssh_macs_53_default }}'


### PR DESCRIPTION
RedHad Enterprise Linux (and family) support SHA2 HMACs as of RHEL 6.5.  Please see [Detailed notes on the changes implemented in Red Hat Enterprise Linux 6.5](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html-single/6.5_technical_notes/index#openssh) (BZ#969565).

This changes the default HMAC configuration on CentOS/RHEL >= 6.5 to the settings recommended by CIS guidelines.

This also fixes ssh connectivity issues in mixed RHEL6/RHEL7 environments, as the default OpenSSH 5.3 configuration has no overlapping HMACs with 7.4.
