### PR TITLE
Disable also dynamic MOTD via PAM if enabled - refs #271

### DIFF
--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -41,6 +41,18 @@
   notify: restart sshd
   when: ssh_server_hardening | bool
 
+- name: disable dynamic MOTD
+  pamd:
+    name: sshd
+    type: session
+    control: optional
+    module_path: pam_motd.so
+    state: absent
+  when:
+    - ssh_server_hardening | bool
+    - ssh_pam_support | bool
+    - not (ssh_print_motd | bool)
+
 - name: create ssh_config and set permissions to root/644
   template:
     src: 'openssh.conf.j2'


### PR DESCRIPTION
If the MOTD shall be disabled **and** the PAM support is enabled **and** we actually are hardening the server-side, then also disable the dynamic one as enabled by default in e.g. Ubuntu.