### PR TITLE
fix(ansible_facts): replace few remaining facts from 'ansible_' to using 'ansible_facts' dictionary

### DIFF
--- a/tasks/crypto.yml
+++ b/tasks/crypto.yml
@@ -36,8 +36,8 @@
   set_fact:
     ssh_macs: '{{ ssh_macs_53_el_6_5_default }}'
   when:
-    - ansible_distribution in ['CentOS', 'OracleLinux', 'RedHat']
-    - ansible_distribution_version is version('6.5', '>=')
+    - ansible_facts.distribution in ['CentOS', 'OracleLinux', 'RedHat']
+    - ansible_facts.distribution_version is version('6.5', '>=')
     - not ssh_macs
 
 - name: set macs according to openssh-version

--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -83,4 +83,4 @@
 
 - name: include selinux specific tasks
   include_tasks: selinux.yml
-  when: ansible_selinux and ansible_selinux.status == "enabled"
+  when: ansible_facts.selinux and ansible_facts.selinux.status == "enabled"


### PR DESCRIPTION
Following [Ansible Documentation on Facts](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variables-discovered-from-systems-facts) this MR replaces couple of variables remaining which are using injected variables prefixed with `ansible_`

Using facts with this prefix was changed with Ansible 2.5, and should be disabled by default in future releases. In cases where users choose to force only `ansible_facts` to be used by setting `inject_facts_as_vars` to *False*, using older naming leads to errors when applying the role.
