### PR TITLE
feat: Allow to set custom list of HostKeyAlgorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_client_port` | '22' |port to which ssh-client should connect|
 |`ssh_listen_to` | ['0.0.0.0'] |one or more ip addresses, to which ssh-server should listen to. Default is all adresseses, but should be configured to specific addresses for security reasons!|
 |`ssh_host_key_files` | [] |Host keys for sshd. If empty ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key'] will be used, as far as supported by the installed sshd version|
+|`ssh_host_key_algorithms` | [] | Host key algorithms that the server offers. If empty the [default list](https://man.openbsd.org/sshd_config#HostKeyAlgorithms) will be used, otherwise overrides the setting with specified list of algorithms|
 |`ssh_client_alive_interval` | 600 | specifies an interval for sending keepalive messages |
 |`ssh_client_alive_count` | 3 | defines how often keep-alive messages are sent |
 |`ssh_permit_tunnel` | false | true if SSH Port Tunneling is required |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,9 @@ ssh_listen_to: ['0.0.0.0']    # sshd
 # Host keys to look for when starting sshd.
 ssh_host_key_files: []  # sshd
 
+# Specifies the host key algorithms that the server offers
+ssh_host_key_algorithms: []  # sshd
+
 # Specifies  the  maximum  number  of authentication attempts permitted per connection.  Once the number of failures reaches half this value, additional failures are logged.
 ssh_max_auth_retries: 2
 

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -35,6 +35,9 @@ ListenAddress {{address}}
 HostKey {{key}}
 {% endfor %}
 
+# Specifies the host key algorithms that the server offers.
+{{ "HostKeyAlgorithms "+ssh_host_key_algorithms| join(',') if ssh_host_key_algorithms else "HostKeyAlgorithms"|comment }}
+
 # Security configuration
 # ======================
 

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -36,7 +36,9 @@ HostKey {{key}}
 {% endfor %}
 
 # Specifies the host key algorithms that the server offers.
+{% if sshd_version is version('5.8', '>=') %}
 {{ "HostKeyAlgorithms "+ssh_host_key_algorithms| join(',') if ssh_host_key_algorithms else "HostKeyAlgorithms"|comment }}
+{% endif %}
 
 # Security configuration
 # ======================

--- a/tests/default_custom.yml
+++ b/tests/default_custom.yml
@@ -77,6 +77,11 @@
     ssh_authorized_principals_file: '/etc/ssh/auth_principals/%u'
     ssh_authorized_principals:
       - { path: '/etc/ssh/auth_principals/root', principals: [ 'root' ], owner: "{{ ssh_owner }}", group: "{{ ssh_group }}", directoryowner: "{{ ssh_owner }}", directorygroup: "{{ ssh_group}}" }
+    ssh_host_key_algorithms:
+      - ssh-ed25519
+      - rsa-sha2-512
+      - rsa-sha2-256
+      - ssh-rsa
     ssh_macs:
       - hmac-sha2-512
       - hmac-sha2-256


### PR DESCRIPTION
This MR follows the same concept for Host Key Algorithms as Macs and Kex
Default is an empty list, which can be set as a variable when applying the role.
If custom list is provided - it will be used to set `HostKeyAlgorithms` in `sshd_config`

The only difference from Macs and Kex, is that this setting will be honoured only from version 5.8 of SSH daemon, as earlier version do not have this feature.

I can also confirm that it works on Oracle Linux 7. ( currently not tested by Travis )
Solves #243