### PR TITLE
fix: Amazon linux build

### DIFF
--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -87,7 +87,7 @@ LogLevel {{ sshd_log_level }}
 UseLogin no
 {% endif %}
 {% if sshd_version is version('7.5', '<') %}
-UsePrivilegeSeparation {% if (ansible_facts.distribution == 'Debian' and ansible_facts.distribution_major_version <= '6') or (ansible_facts.os_family in ['Oracle Linux', 'RedHat'] and ansible_facts.distribution_major_version <= '6') -%}{{ssh_ps53}}{% else %}{{ssh_ps59}}{% endif %}
+UsePrivilegeSeparation {% if (ansible_facts.distribution == 'Debian' and ansible_facts.distribution_major_version <= '6') or (ansible_facts.os_family in ['Oracle Linux', 'RedHat'] and ansible_facts.distribution_major_version <= '6' and not ansible_facts.distribution == 'Amazon') -%}{{ssh_ps53}}{% else %}{{ssh_ps59}}{% endif %}
 {% endif %}
 
 LoginGraceTime 30s

--- a/tests/default.yml
+++ b/tests/default.yml
@@ -17,7 +17,9 @@
     - file: path="/var/run/sshd" state=directory
     - name: create ssh host keys
       command: "ssh-keygen -A"
-      when: not ((ansible_facts.os_family in ['Oracle Linux', 'RedHat']) and ansible_facts.distribution_major_version < '7') or ansible_facts.distribution == "Fedora"
+      when: not ((ansible_facts.os_family in ['Oracle Linux', 'RedHat']) and ansible_facts.distribution_major_version < '7') or 
+            ansible_facts.distribution == "Fedora" or
+            ansible_facts.distribution == "Amazon"
 
   roles:
     - ansible-ssh-hardening

--- a/tests/default_custom.yml
+++ b/tests/default_custom.yml
@@ -17,7 +17,9 @@
     - file: path="/var/run/sshd" state=directory
     - name: create ssh host keys
       command: "ssh-keygen -A"
-      when: not ((ansible_facts.os_family in ['Oracle Linux', 'RedHat']) and ansible_facts.distribution_major_version < '7') or ansible_facts.distribution == "Fedora"
+      when: not ((ansible_facts.os_family in ['Oracle Linux', 'RedHat']) and ansible_facts.distribution_major_version < '7') or 
+            ansible_facts.distribution == "Fedora" or
+            ansible_facts.distribution == "Amazon"
 
   roles:
     - ansible-ssh-hardening


### PR DESCRIPTION
Amazon linux is a peculiar distribution as its `os_family` is `RedHat`, but `distribution_major_version` is *2*, which successfully met the conditional in *tests* and did not generate `SSH keys` which caused the role to fail validating the sshd_config against non existing files.

The same condition was met in the template itself for  `UsePrivilegeSeparation` directive, incorrectly setting the value and causing `sshd-16` inspect check to fail.

This PR addresses both of these issues returning Amazon linux based build to green.