### PR TITLE
fix: Ansible part of Fedora build

### DIFF
--- a/tests/default.yml
+++ b/tests/default.yml
@@ -2,11 +2,17 @@
 - name: wrapper playbook for kitchen testing "ansible-ssh-hardening" with default settings
   hosts: localhost
   pre_tasks:
-    - package: name="{{item}}" state=present
-      with_items:
-        - "openssh-client"
-        - "openssh-server"
-        - "python-selinux"
+    - name: use python3
+      set_fact:
+        ansible_python_interpreter: /usr/bin/python3
+      when: ansible_facts.distribution == 'Fedora'
+
+    - package: name="{{ packages }}" state=present
+      vars:
+        packages:
+          - openssh-clients
+          - openssh-server
+          - libselinux-python
       ignore_errors: true
     - apt: name="{{packages}}" state=present update_cache=true
       vars:

--- a/tests/default_custom.yml
+++ b/tests/default_custom.yml
@@ -2,11 +2,17 @@
 - name: wrapper playbook for kitchen testing "ansible-ssh-hardening" with custom settings
   hosts: localhost
   pre_tasks:
-    - package: name="{{item}}" state=present
-      with_items:
-        - "openssh-clients"
-        - "openssh-server"
-        - "libselinux-python"
+    - name: use python3
+      set_fact:
+        ansible_python_interpreter: /usr/bin/python3
+      when: ansible_facts.distribution == 'Fedora'
+
+    - package: name="{{ packages }}" state=present
+      vars:
+        packages:
+          - openssh-clients
+          - openssh-server
+          - libselinux-python
       ignore_errors: true
     - apt: name="{{packages}}" state=present update_cache=true
       vars:


### PR DESCRIPTION
This MR sets the `python_interpreter` to `python3` for Fedora distribution when running the tests.
This fixes the provisioning phase, Verification still fails.

[Baseline ](https://github.com/dev-sec/ssh-baseline/blob/5d8da165bde321a5e1bb5e2023e9735cd2373f38/libraries/ssh_crypto.rb#L97 )will need to be updated with `kex_80` for fedora in a separate PR. 