### PR TITLE
make ssh client-side compression configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_banner` | `false` | `true` to print a banner on login |
 |`ssh_client_hardening` | `true` | `false` to stop harden the client |
 |`ssh_client_port` | `'22'` | Specifies the port number to connect on the remote host. |
-|`ssh_compression` | `false` | Specifies whether compression is enabled after the user has authenticated successfully. |
+|`ssh_client_compression` | `false` | Specifies whether the client requests compression. |
+|`ssh_compression` | `false` | Specifies whether server-side compression is enabled after the user has authenticated successfully. |
 |`ssh_max_auth_retries` | `2` | Specifies the maximum number of authentication attempts permitted per connection. |
 |`ssh_print_debian_banner` | `false` | `true` to print debian specific banner |
 |`ssh_server_enabled` | `true` | `false` to disable the opensshd server |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ ssh_server_enabled: true               # sshd
 ssh_use_dns: false                      # sshd
 
 # true or value if compression is needed
+ssh_client_compression: false           # ssh
 ssh_compression: false                  # sshd
 
 # For which components (client and server) to generate the configuration for. Can be useful when running against a client without an SSH server.

--- a/templates/openssh.conf.j2
+++ b/templates/openssh.conf.j2
@@ -113,8 +113,7 @@ PermitLocalCommand no
 # Misc. configuration
 # ===================
 
-# Enable compression. More pressure on the CPU, less on the network.
-Compression yes
+Compression {{ 'yes' if (ssh_client_compression|bool) else 'no' }}
 
 #EscapeChar ~
 #VisualHostKey yes


### PR DESCRIPTION
It came as a big surprise to me that the client configuration hardcodes compression by default.

This makes it configurable, and sets it to `false` by default. This is a change in behavior, but I think is the correct one. It brings it in line with upstream SSH defaults, and compression has little to do with security (which is the primary goal of this role).

I chose not to rename `ssh_compression` to `ssh_server_compression` because I did not want to cause breakage for those already using it. Please feel free to adjust this PR if you would prefer the more specific naming.