### PR TITLE
add SmartOS support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,7 @@ galaxy_info:
     - name: Amazon
     - name: Fedora
     - name: Archlinux
+    - name: SmartOS
   galaxy_tags:
     - system
     - security

--- a/tasks/crypto_hostkeys.yml
+++ b/tasks/crypto_hostkeys.yml
@@ -1,15 +1,21 @@
 ---
 - name: set hostkeys according to openssh-version if openssh >= 5.3
   set_fact:
-    ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key']
+    ssh_host_key_files:
+      - "{{ ssh_host_keys_dir }}/ssh_host_rsa_key"
   when: sshd_version is version('5.3', '>=')
 
 - name: set hostkeys according to openssh-version if openssh >= 6.0
   set_fact:
-    ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key']
+    ssh_host_key_files:
+      - "{{ ssh_host_keys_dir }}/ssh_host_rsa_key"
+      - "{{ ssh_host_keys_dir }}/ssh_host_ecdsa_key"
   when: sshd_version is version('6.0', '>=')
 
 - name: set hostkeys according to openssh-version if openssh >= 6.3
   set_fact:
-    ssh_host_key_files: ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key']
+    ssh_host_key_files:
+      - "{{ ssh_host_keys_dir }}/ssh_host_rsa_key"
+      - "{{ ssh_host_keys_dir }}/ssh_host_ecdsa_key"
+      - "{{ ssh_host_keys_dir }}/ssh_host_ed25519_key"
   when: sshd_version is version('6.3', '>=')

--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -50,7 +50,7 @@
     mode: '0600'
     owner: '{{ ssh_owner }}'
     group: '{{ ssh_group }}'
-    validate: '/usr/sbin/sshd -T -C user=root -C host=localhost -C addr=localhost -C lport=22 -f %s'
+    validate: '{{ sshd_path }} -T -C user=root -C host=localhost -C addr=localhost -C lport=22 -f %s'
   notify: restart sshd
   when: ssh_server_hardening | bool
 

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,5 +1,6 @@
 ---
 sshd_path: /usr/sbin/sshd
+ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,3 +1,5 @@
+---
+sshd_path: /usr/sbin/sshd
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,5 @@
 ---
+sshd_path: /usr/sbin/sshd
 sshd_service_name: ssh
 ssh_owner: root
 ssh_group: root

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,6 @@
 ---
 sshd_path: /usr/sbin/sshd
+ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: ssh
 ssh_owner: root
 ssh_group: root

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,5 +1,6 @@
 ---
 sshd_path: /usr/sbin/sshd
+ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,4 +1,5 @@
 ---
+sshd_path: /usr/sbin/sshd
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,5 +1,6 @@
 ---
 sshd_path: /usr/sbin/sshd
+ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: wheel

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,4 +1,5 @@
 ---
+sshd_path: /usr/sbin/sshd
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: wheel

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -1,5 +1,6 @@
 ---
 sshd_path: /usr/sbin/sshd
+ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: wheel

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -1,4 +1,5 @@
 ---
+sshd_path: /usr/sbin/sshd
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: wheel

--- a/vars/Oracle Linux.yml
+++ b/vars/Oracle Linux.yml
@@ -1,5 +1,6 @@
 ---
 sshd_path: /usr/sbin/sshd
+ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root

--- a/vars/Oracle Linux.yml
+++ b/vars/Oracle Linux.yml
@@ -1,4 +1,5 @@
 ---
+sshd_path: /usr/sbin/sshd
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,6 @@
 ---
 sshd_path: /usr/sbin/sshd
+ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,5 @@
 ---
+sshd_path: /usr/sbin/sshd
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -1,5 +1,6 @@
 ---
 sshd_path: /usr/sbin/sshd
+ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -1,4 +1,5 @@
 ---
+sshd_path: /usr/sbin/sshd
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root

--- a/vars/SmartOS.yml
+++ b/vars/SmartOS.yml
@@ -1,5 +1,6 @@
 ---
 sshd_path: /usr/lib/ssh/sshd
+ssh_host_keys_dir: '/var/ssh'
 sshd_service_name: ssh
 ssh_owner: root
 ssh_group: root

--- a/vars/SmartOS.yml
+++ b/vars/SmartOS.yml
@@ -1,0 +1,7 @@
+---
+sshd_path: /usr/lib/ssh/sshd
+sshd_service_name: ssh
+ssh_owner: root
+ssh_group: root
+
+ssh_pam_support: false


### PR DESCRIPTION
In addition to a new SmartOS.yml var file, this PR makes configurable the location of sshd (`sshd_path`) and ssh host keys (`ssh_host_keys_dir`).

The introduction of `ssh_host_keys_dir` is not strictly necessary, as the user can specify `ssh_host_key_files`. For that reason, I split it into its own commit, so you can cherry-pick around it if you so choose. However, I felt adding it was preferable, as it will work out-of-the-box, and doesn't require the user to keep `ssh_host_key_files` and `ssh_host_key_algorithms` in sync.

Neither of these were added to the README, as it seems to focus on user-visible variables, which neither of these are.