### PR TITLE
README: New section on server port and idempotency

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Example playbook:
       - "AcceptEnv LANG"
 ```
 
+## Changing the default port and idempotency
+
+This role uses the default port 22 or the port configured in the inventory to connect to the server. If the default `ssh` port is changed via `ssh_server_ports`, once the ssh server is restarted, it will still try to connect using the previous port. In order to run this role again on the same server the inventory will have to be updated to use the new ssh port.
+
+If idempotency is important, please consider using role [`ssh-hardening-fallback`](https://github.com/nununo/ansible-ssh-hardening-fallback), which is a wrapper around this role that falls back to port 22 if the configured port is unreachable.
+
 ## Example Playbook
 
     - hosts: localhost


### PR DESCRIPTION
Add section called "Changing the default port and idempotency" and reference to role ssh-hardening-fallback, a wrapper around this role which implements a fallback to port 22 when the configured port is unreachable.

Closes #299.

Signed-off-by: Nuno Godinho <user@nunogodinho.com>