### PR TITLE
add support for CentOS8

### DIFF
--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -33,6 +33,9 @@ platforms:
 - name: centos-7
   driver_config:
     box: bento/centos-7
+- name: centos-8
+  driver_config:
+    box: bento/centos-8
 - name: oracle-6
   driver_config:
     box: bento/oracle-6

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,6 +36,20 @@ platforms:
     provision_command:
       - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
       - systemctl enable sshd.service
+- name: centos8-ansible-latest
+  driver:
+    image: rndmh3ro/docker-centos8-ansible:latest
+    platform: centos
+    cap_add:
+      - SYS_ADMIN
+    volume:
+      - /sys/fs/cgroup:/sys/fs/cgroup
+    run_command: /sbin/init
+    provision_command:
+      - sed -i '/nologin/d' /etc/pam.d/sshd
+      - systemctl enable sshd.service
+  provisioner:
+    ansible_binary_path: "/usr/local/bin"
 - name: oracle6-ansible-latest
   driver:
     image: rndmh3ro/docker-oracle6-ansible:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     version: latest
 
   - distro: centos8
-    init: /usr/lib/systemd/systemd
+    init: /sbin/init
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     version: latest
 
@@ -78,7 +78,7 @@ script:
 
   # Verify role
   # remove the UseLogin-check, see here for reasons: https://github.com/dev-sec/ansible-ssh-hardening/pull/141
-  - 'inspec exec https://github.com/dev-sec/ssh-baseline/ -t docker://$(cat ${container_id}) --controls=sshd-01 sshd-02 sshd-03 sshd-04 sshd-05 sshd-06 sshd-07 sshd-08 sshd-09 sshd-10 sshd-11 sshd-12 sshd-13 sshd-14 sshd-15 sshd-16 sshd-17 sshd-18 sshd-19 sshd-20 sshd-21 sshd-22 sshd-23 sshd-24 sshd-25 sshd-26 sshd-27 sshd-28 sshd-29 sshd-30 sshd-31 sshd-32 sshd-33 sshd-34 sshd-35 sshd-36 sshd-37 sshd-38 sshd-39 sshd-40 sshd-41 sshd-42 sshd-43 sshd-44 sshd-45 sshd-46 sshd-47 sshd-48 --no-distinct-exit'
+  - 'inspec exec https://github.com/dev-sec/ssh-baseline/ -t docker://$(cat ${container_id}) --controls=sshd-01 sshd-02 sshd-03 sshd-04 sshd-05 sshd-06 sshd-07 sshd-08 sshd-09 sshd-10 sshd-11 sshd-12 sshd-13 sshd-14 sshd-15 sshd-16 sshd-17 sshd-18 sshd-19 sshd-20 sshd-21 sshd-22 sshd-23 sshd-24 sshd-25 sshd-26 sshd-27 sshd-28 sshd-29 sshd-30 sshd-31 sshd-32 sshd-33 sshd-34 sshd-35 sshd-36 sshd-37 sshd-38 sshd-39 sshd-40 sshd-41 sshd-42 sshd-43 sshd-44 sshd-45 sshd-46 sshd-47 sshd-48 sshd-49 --no-distinct-exit'
   # remove UseRoaming and RhostsRSAAuthentication because these options are deprecated - ssh-14, ssh-15, ssh-21
   - 'inspec exec https://github.com/dev-sec/ssh-baseline/ -t docker://$(cat ${container_id}) --controls=ssh-01 ssh-02 ssh-03 ssh-04 ssh-05 ssh-06 ssh-07 ssh-08 ssh-09 ssh-10 ssh-11 ssh-12 ssh-13 ssh-14 ssh-15 ssh-16 ssh-17 ssh-18 ssh-19 ssh-20 --no-distinct-exit'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
     version: latest
 
   - distro: centos8
-    init: /sbin/init
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw"
     version: latest
 
   - distro: oracle6

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ env:
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     version: latest
 
+  - distro: centos8
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    version: latest
+
   - distro: oracle6
     version: latest
     init: /sbin/init

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -262,3 +262,7 @@ sshd_syslog_facility: 'AUTH'
 sshd_log_level: 'VERBOSE'
 
 sshd_strict_modes: yes
+
+# disable CRYPTO_POLICY to take settings from sshd configuration
+# see: https://access.redhat.com/solutions/4410591
+sshd_disable_crypto_policy: true

--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -97,3 +97,13 @@
 - name: include selinux specific tasks
   include_tasks: selinux.yml
   when: ansible_facts.selinux and ansible_facts.selinux.status == "enabled"
+
+- name: disable system CRYPTO_POLICY for RHEL8+
+  lineinfile:
+    path: /etc/sysconfig/sshd
+    regexp: 'CRYPTO_POLICY='
+    line: CRYPTO_POLICY=
+  when:
+    - ansible_facts.distribution in ['CentOS', 'OracleLinux', 'RedHat']
+    - ansible_facts.distribution_version is version('8.0', '>=')
+    - sshd_disable_crypto_policy | bool


### PR DESCRIPTION
Adds testing environments for CentOS8 to local Kitchen and remote Travis
tests. Currently only local Kitchen Docker tests are verified.

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>