### PR TITLE
rework CRYPTO_POLICY handling for fedora

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -111,7 +111,7 @@ platforms:
     image: rndmh3ro/docker-fedora-ansible:latest
     platform: centos
     provision_command:
-      - dnf install -y python
+      - dnf install -y python procps-ng
       - sed -i '/nologin/d' /etc/pam.d/sshd
       - systemctl enable sshd.service
 

--- a/files/sshd
+++ b/files/sshd
@@ -1,0 +1,17 @@
+# Configuration file for the sshd service.
+
+# The server keys are automatically generated if they are missing.
+# To change the automatic creation, adjust sshd.service options for
+# example using  systemctl enable sshd-keygen@dsa.service  to allow creation
+# of DSA key or  systemctl mask sshd-keygen@rsa.service  to disable RSA key
+# creation.
+
+# Do not change this option unless you have hardware random
+# generator and you REALLY know what you are doing
+
+SSH_USE_STRONG_RNG=0
+# SSH_USE_STRONG_RNG=1
+
+# System-wide crypto policy:
+# To opt-out, uncomment the following line
+CRYPTO_POLICY=

--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -98,19 +98,16 @@
   include_tasks: selinux.yml
   when: ansible_facts.selinux and ansible_facts.selinux.status == "enabled"
 
-- name: check SSH server CRYPTO_POLICY
-  find:
-    path: /etc/sysconfig
-    pattern: sshd
-    contains: '.*CRYPTO_POLICY=.*'
-  register: crypto_policy
+- name: gather package facts
+  package_facts:
   check_mode: no
+  when:
+    - sshd_disable_crypto_policy | bool
 
 - name: disable SSH server CRYPTO_POLICY
-  lineinfile:
-    path: /etc/sysconfig/sshd
-    regexp: 'CRYPTO_POLICY='
-    line: CRYPTO_POLICY=
+  copy:
+    src: sshd
+    dest: /etc/sysconfig/sshd
   when:
-    - crypto_policy.matched > 0
+    - ('crypto-policies' in ansible_facts.packages)
     - sshd_disable_crypto_policy | bool

--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -98,12 +98,19 @@
   include_tasks: selinux.yml
   when: ansible_facts.selinux and ansible_facts.selinux.status == "enabled"
 
-- name: disable system CRYPTO_POLICY for RHEL8+
+- name: check SSH server CRYPTO_POLICY
+  find:
+    path: /etc/sysconfig
+    pattern: sshd
+    contains: '.*CRYPTO_POLICY=.*'
+  register: crypto_policy
+  check_mode: no
+
+- name: disable SSH server CRYPTO_POLICY
   lineinfile:
     path: /etc/sysconfig/sshd
     regexp: 'CRYPTO_POLICY='
     line: CRYPTO_POLICY=
   when:
-    - ansible_facts.distribution in ['CentOS', 'OracleLinux', 'RedHat']
-    - ansible_facts.distribution_version is version('8.0', '>=')
+    - crypto_policy.matched > 0
     - sshd_disable_crypto_policy | bool

--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -109,5 +109,5 @@
     src: sshd
     dest: /etc/sysconfig/sshd
   when:
-    - ('crypto-policies' in ansible_facts.packages)
     - sshd_disable_crypto_policy | bool
+    - ('crypto-policies' in ansible_facts.packages)

--- a/tests/default.yml
+++ b/tests/default.yml
@@ -20,6 +20,7 @@
         name:
           - openssh-clients
           - openssh-server
+          - procps-ng
         state: present
         update_cache: true
       ignore_errors: true

--- a/tests/default_custom.yml
+++ b/tests/default_custom.yml
@@ -20,6 +20,7 @@
         name:
           - openssh-clients
           - openssh-server
+          - procps-ng
         state: present
         update_cache: true
       ignore_errors: true

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,3 +1,7 @@
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root
+
+# CRYPTO_POLICY is not supported on Archlinux 
+# and the package check only works in Ansible >2.10
+sshd_disable_crypto_policy: false


### PR DESCRIPTION
the previous implementation did not handle fedora right. Now we check if
a CRYPTO_POLICY is present regardless of the OS version.

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>