### PR TITLE
fix sftp_umask; store as literal not octal

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_print_motd` | false | false to disable printing of the MOTD|
 |`ssh_print_last_log` | false | false to disable display of last login information|
 |`sftp_enabled` | false | true to enable sftp configuration|
-|`sftp_umask` | 0027 | Specifies the umask for sftp|
+|`sftp_umask` | '0027' | Specifies the umask for sftp|
 |`sftp_chroot` | true | false to disable chroot for sftp|
 |`sftp_chroot_dir` | /home/%u | change default sftp chroot location|
 |`ssh_client_roaming` | false | enable experimental client roaming|

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -153,7 +153,7 @@ sftp_enabled: false
 sftp_chroot: true
 
 # sftp default umask
-sftp_umask: 0027
+sftp_umask: '0027'
 
 # change default sftp chroot location
 sftp_chroot_dir: /home/%u


### PR DESCRIPTION
Numbers with leading zeros need to be quoted in Ansible, otherwise they are interpreted as octal. Which the templating happily writes out in... decimal.

In this case, sftp_umask 0027 was ending up as 23 in sshd.conf.

On a Debian Buster system, fixing this did not result in a change in the default umask applied, so I assume that `internal-sftp` ignored '23' and fell back to 0027 as its default (as is the case on Debian). Other distros/systems with alternate defaults will likely experience a change in behavior.