### PR TITLE
fix local kitchen tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,7 +5,12 @@ driver:
   cap_add:
     - SYS_ADMIN
   volume:
-    - /sys/fs/cgroup:/sys/fs/cgroup
+    - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  run_options:
+    tmpfs:
+      - /tmp
+      - /run
+      - /run/lock
   run_command: /sbin/init
   http_proxy: <%= ENV['http_proxy'] || nil %>
   https_proxy: <%= ENV['https_proxy'] || nil %>


### PR DESCRIPTION
somehow a "real" linux needs different options than WSL. This is now
also working on debian 10

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>