### PR TITLE
add separate option for controlling motd via pam

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
 |`ssh_authorized_principals_file` | '' | specifies the file containing principals that are allowed. Only used if ssh_trusted_user_ca_keys_file is set. |
 |`ssh_authorized_principals` | [] | list of hashes containing file paths and authorized principals, see default_custom.yml for all options. Only used if ssh_authorized_principals_file is set. |
 |`ssh_print_motd` | false | false to disable printing of the MOTD|
+|`ssh_print_pam_motd` | false | false to disable printing of the MOTD via pam (Debian and Ubuntu)|
 |`ssh_print_last_log` | false | false to disable display of last login information|
 |`sftp_enabled` | false | true to enable sftp configuration|
 |`sftp_umask` | '0027' | Specifies the umask for sftp|

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -133,6 +133,7 @@ ssh_authorized_principals: []       # sshd
 
 # false to disable printing of the MOTD
 ssh_print_motd: false               # sshd
+ssh_print_pam_motd: false           # sshd
 
 # false to disable display of last login information
 ssh_print_last_log: false           # sshd

--- a/tasks/hardening.yml
+++ b/tasks/hardening.yml
@@ -61,10 +61,11 @@
     control: optional
     module_path: pam_motd.so
     state: absent
+    backup: yes
   when:
     - ssh_server_hardening | bool
     - ssh_pam_support | bool
-    - not (ssh_print_motd | bool)
+    - not (ssh_print_pam_motd | bool)
 
 - name: create ssh_config and set permissions to root/644
   template:


### PR DESCRIPTION
makes it possible to set different values for motd via sshd and pam.
Also create a backup file of pam configuration, to allow user to restore
the previous settings.

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>