### PR TITLE
add EulerOS vars

### DIFF
--- a/vars/EulerOS.yml
+++ b/vars/EulerOS.yml
@@ -1,0 +1,9 @@
+---
+sshd_path: /usr/sbin/sshd
+ssh_host_keys_dir: '/etc/ssh'
+sshd_service_name: sshd
+ssh_owner: root
+ssh_group: root
+ssh_selinux_packages:
+  - policycoreutils-python
+  - checkpolicy


### PR DESCRIPTION
This adds variables for EulerOS, a distribution by Huawei which is based on/similar to RedHat/CentOS.

I've tested it with EulerOS 2.0 SP5. 

https://developer.huaweicloud.com/en-us/euleros/euleros-introduction.html