### PR TITLE
Fix PasswordAuthentication for sftponly

### DIFF
--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -257,7 +257,7 @@ Match Group sftponly
 {% endif %}
     AllowTcpForwarding no
     AllowAgentForwarding no
-    PasswordAuthentication no
+    PasswordAuthentication {{ 'yes' if (ssh_server_password_login|bool) else 'no' }}
     PermitRootLogin no
     X11Forwarding no
 {% endif %}


### PR DESCRIPTION
If `ssh_server_password_login` is enabled, it seems to me like password authentication should also be enabled for the sftponly group.